### PR TITLE
Fix 414 errors due to too long URL

### DIFF
--- a/front/src/usecases/index.ts
+++ b/front/src/usecases/index.ts
@@ -11,7 +11,7 @@ import { ITimetableUseCase, TimetableUseCase } from "./timetable";
 
 const transport = createConnectTransport({
   baseUrl: import.meta.env.VITE_API_URL,
-  useBinaryFormat: false,
+  useBinaryFormat: true,
   credentials: "include",
   useHttpGet: true,
 });


### PR DESCRIPTION
## 背景

Fixes #93 

## 変更

差分通り
まず選択肢として検索クエリを

- 現行の通り GET の  search prams で渡すか
- POST の body で渡すか（V3 はこれ）

があった。検索は冪等でありキャッシュされても構わないため GET が望ましいので前者の方針にした。

前者の方針を維持するためには binary mode にし内容を圧縮する必要があり、今回の変更を実施した。
その結果以下のように params が短くなり 414 エラーが発生しなくなった。

![image](https://github.com/user-attachments/assets/8eaa13e0-184e-4a81-bc9e-b74621b59964)

binary mode だとログが見づらい、という観点もあったが、GET を用いることを優先した。
