### PR TITLE
[front] 授業詳細に「授業場所の登録」へのリンクを追加

### DIFF
--- a/front/src/ui/pages/course/_id/index.vue
+++ b/front/src/ui/pages/course/_id/index.vue
@@ -55,11 +55,16 @@
                 displayCourse.room
               }}</template>
               <template v-else>
-                <RouterLink
-                  class="add-room-link"
-                  :to="`/course/${id}/edit#section-rooms`"
-                  >教室情報を追加する</RouterLink
-                >
+                <div class="add-room-links">
+                  <RouterLink
+                    class="add-room-link"
+                    :to="`/course/${id}/edit#section-rooms`"
+                    >手動で入力する</RouterLink
+                  >
+                  <RouterLink class="add-room-link" to="/import-room"
+                    >Excelからインポートする</RouterLink
+                  >
+                </div>
               </template>
             </template>
           </CourseDetail>
@@ -455,6 +460,13 @@ if (displayCourse.value.code === "") popupContents.splice(1, 1);
       grid-area: minus-btn;
     }
   }
+}
+
+.add-room-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: left;
+  gap: 1.2rem 0.8rem;
 }
 
 .add-room-link {


### PR DESCRIPTION
授業詳細に`/import-room`へのリンクを追加しました。
<img width="1628" alt="Screenshot 2025-05-07 at 9 24 27" src="https://github.com/user-attachments/assets/2573e0f0-3239-422b-abd9-bd790eb536f6" />
