### PR TITLE
[front] SentryのtracingOriginsを修正

### DIFF
--- a/front/src/ui/main.ts
+++ b/front/src/ui/main.ts
@@ -16,7 +16,7 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       router,
-      tracingOrigins: ["app.twinte.net"],
+      tracePropagationTargets: ["localhost", /^https:\/\/app\.twinte\.net/],
     }),
     Sentry.replayIntegration({
       maskAllText: false,


### PR DESCRIPTION
Google ChromeとSafariでCORSエラーが表示されないことを確認しました