### PR TITLE
[front] Sentryにenvironmentを設定する

### DIFF
--- a/front/src/ui/main.ts
+++ b/front/src/ui/main.ts
@@ -13,6 +13,7 @@ const app = createApp(App);
 Sentry.init({
   app,
   dsn: String(import.meta.env.VITE_APP_SENTRY_URL ?? ""),
+  environment: import.meta.env.DEV ? "development" : undefined,
   integrations: [
     Sentry.browserTracingIntegration({
       router,


### PR DESCRIPTION
meta.envがDevの場合にDevelopmentをつけるようにしました、Development出ない場合はundefinedを渡していますがSentry側でProductionが勝手に付けられるようでした

https://twin-te.sentry.io/feedback/?feedbackSlug=front%3A6759728546&project=4504226167324672