### PR TITLE
[back] goのバージョンを1.24.6に更新

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.5
+ARG GO_VERSION=1.24.6
 FROM golang:${GO_VERSION} AS base
 WORKDIR /usr/src/twin-te/back
 

--- a/back/go.mod
+++ b/back/go.mod
@@ -1,6 +1,6 @@
 module github.com/twin-te/twin-te/back
 
-go 1.24.5
+go 1.24.6
 
 require (
 	cloud.google.com/go v0.116.0


### PR DESCRIPTION
Goの脆弱性情報を受けて更新
ref: https://groups.google.com/g/golang-nuts/c/DMo9_H8-sAw

デプロイ向けのバイナリがgo.1.24.6でビルドされたことは確認しました
```
% go version app 
app: go1.24.6
```