### PR TITLE
[front] 「Appleでログイン」のボタンを一時的に削除

### DIFF
--- a/front/src/ui/pages/login.vue
+++ b/front/src/ui/pages/login.vue
@@ -14,13 +14,13 @@
       </div>
       <div class="main__head">ログイン方法を選択</div>
       <div class="main__provider">
-        <button @click="login('apple')">
+        <!-- <button @click="login('apple')">
           <img
             class="main__login-button"
             src="../assets/login-page/login-apple.png"
             alt="appleでログイン"
           />
-        </button>
+        </button> -->
         <button
           class="main__login-button main__btn-x"
           @click="login('twitter')"

--- a/front/src/ui/pages/login.vue
+++ b/front/src/ui/pages/login.vue
@@ -14,6 +14,9 @@
       </div>
       <div class="main__head">ログイン方法を選択</div>
       <div class="main__provider">
+        <div class="main__note">
+          現在Appleアカウントでのサインインはメンテナンス中です。
+        </div>
         <!-- <button @click="login('apple')">
           <img
             class="main__login-button"


### PR DESCRIPTION
iOSアプリのメンテナンス用
メンテナンスが終わり次第revertする