### PR TITLE
[front] 「通知設定を開く」ボタンが右寄せにならない問題を修正

### DIFF
--- a/front/src/ui/pages/settings.vue
+++ b/front/src/ui/pages/settings.vue
@@ -275,7 +275,8 @@ const confirmDeleteAccount = async () => {
     padding: 1.2rem 0;
     color: getColor(--color-text-main);
     font-weight: 500;
-    & .switch {
+    & .switch,
+    & .button {
       margin: 0 0 0 auto;
     }
     &--dropdown {


### PR DESCRIPTION
close #354 

| 変更前 | 変更後 |
| --- | --- |
| <img width="772" height="1552" alt="localhost_4000_settings (1)" src="https://github.com/user-attachments/assets/2e73aee6-b884-4bd3-96fe-5debdf6b517d" /> | <img width="772" height="1552" alt="localhost_4000_settings" src="https://github.com/user-attachments/assets/00b8b84a-29ee-4a64-ba66-061b43fc4e24" /> |

