### PR TITLE
[parser] sentry の dsn を環境変数から読み込み

### DIFF
--- a/back/.env
+++ b/back/.env
@@ -42,6 +42,7 @@ COOKIE_AUTH_REDIRECT_URL_NAME=twinte_auth_redirect_url
 
 # Sentry
 SENTRY_DSN=https://ceab55b1fbcef72b619687d32a76bff8@o4504011477221376.ingest.us.sentry.io/4509661987209216
+PARSER_SENTRY_DSN=https://5b49dd6c52803ab6747a5148c75f4e15@o4504011477221376.ingest.us.sentry.io/4509354103144448
 
 # others
 TZ=Asia/Tokyo

--- a/parser/download_and_parse.py
+++ b/parser/download_and_parse.py
@@ -3,6 +3,7 @@ import io
 import json
 import pathlib
 import sentry_sdk
+import os
 
 from kdb_downloader import KDBDownloader
 from kdb_parser import parse
@@ -28,10 +29,9 @@ def run_all(year: int) -> str:
 
 
 def main():
-    sentry_sdk.init(
-        dsn="https://5b49dd6c52803ab6747a5148c75f4e15@o4504011477221376.ingest.us.sentry.io/4509354103144448",
-        send_default_pii=True,
-    )
+    dsn = os.getenv("PARSER_SENTRY_DSN")
+    if dsn:
+        sentry_sdk.init(dsn=dsn, send_default_pii=True)
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--year", type=int, required=True, help="academic year")


### PR DESCRIPTION
ローカルとかのエラーで sentry のメールが飛んじゃうので環境変数から読み込むように

以下を .env 系に追記して欲しいです

```
PARSER_SENTRY_DSN="https://5b49dd6c52803ab6747a5148c75f4e15@o4504011477221376.ingest.us.sentry.io/4509354103144448"
```