### PR TITLE
[front] 教室情報を上書きできるようにした

### DIFF
--- a/front/src/ui/pages/import-room/excel.vue
+++ b/front/src/ui/pages/import-room/excel.vue
@@ -257,7 +257,7 @@ async function upload() {
           size="medium"
           layout="fill"
           :state="loadState === 'ok' ? 'default' : 'disabled'"
-          @click="() => (currentStep = 'apply')"
+          @click="currentStep = 'apply'"
         >
           次へ
         </Button>


### PR DESCRIPTION
close #313

教室情報を上書きできるようにしました。
また、一覧にチェックボックスを選択し、選択したもののみ教室情報を登録するように変更しました。

表示例:
<img width="200" alt="localhost_4000_import-room_excel(iPhone XR)" src="https://github.com/user-attachments/assets/53a024c2-e08c-4f32-ba84-8b1aa69559c4" />


