### PR TITLE
[back] idtypeの出力フォーマットを%vに統一

### DIFF
--- a/codegen/idtype/int_template.txt
+++ b/codegen/idtype/int_template.txt
@@ -16,7 +16,7 @@ func (id ${id_name}) IsZero() bool {
 
 func Parse${id_name}(i int) (${id_name}, error) {
 	if i == 0 {
-		return 0, fmt.Errorf("failed to parse ${id_name} %#v", i)
+		return 0, fmt.Errorf("failed to parse ${id_name} %v", i)
 	}
 	return ${id_name}(i), nil
 }

--- a/codegen/idtype/string_template.txt
+++ b/codegen/idtype/string_template.txt
@@ -16,7 +16,7 @@ func (id ${id_name}) IsZero() bool {
 
 func Parse${id_name}(s string) (${id_name}, error) {
 	if s == "" {
-		return "", fmt.Errorf("failed to parse ${id_name} %#v", s)
+		return "", fmt.Errorf("failed to parse ${id_name} %v", s)
 	}
 	return ${id_name}(s), nil
 }


### PR DESCRIPTION
idtypeのテンプレートでは`%#v`が使われているが、テンプレートから生成された実際のコードでは`%v`が使われているので、後者に統一しました。