### PR TITLE
[front] 履修フォーマットのCSVインポートがエラーになる問題を修正

### DIFF
--- a/front/src/ui/pages/add/csv.vue
+++ b/front/src/ui/pages/add/csv.vue
@@ -156,7 +156,7 @@ const readCSV = async (file: File): Promise<CSV> => {
       const line = reader.result
         .split(/\r\n|\r|\n/)
         .filter((v) => v) // drop blank line
-        .map((v) => v.replace(/"/g, ""));
+        .map((v) => v.replace(/"/g, "").trim());
 
       // 履修フォーマット
       if (line[0].length === 7) {


### PR DESCRIPTION
以下のCSVのように行末にスペースが追加されることがエラーの原因でした。
```csv
"XXXXXXX"        
```
各行の文字列に対して`.trim()`を適用してスペースを取り除くことでこのエラーを解消しました。