### PR TITLE
[back, codegen] 2026年度の学年歴を追加

### DIFF
--- a/back/module/schoolcalendar/data/event_gen.json
+++ b/back/module/schoolcalendar/data/event_gen.json
@@ -2419,5 +2419,353 @@
     "date": "2026-03-25",
     "type": "Other",
     "description": "卒業式/学位記授与式"
+  },
+  {
+    "id": 397,
+    "date": "2026-04-06",
+    "type": "Holiday",
+    "description": "入学式"
+  },
+  {
+    "id": 398,
+    "date": "2026-04-07",
+    "type": "Holiday",
+    "description": "学群1年次TOEIC IPテスト"
+  },
+  {
+    "id": 399,
+    "date": "2026-04-06",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "id": 400,
+    "date": "2026-04-07",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "id": 401,
+    "date": "2026-04-08",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "id": 402,
+    "date": "2026-04-09",
+    "type": "Holiday",
+    "description": "オリエンテーション予備日"
+  },
+  {
+    "id": 403,
+    "date": "2026-04-10",
+    "type": "Holiday",
+    "description": "新入生歓迎祭"
+  },
+  {
+    "id": 404,
+    "date": "2026-04-13",
+    "type": "Holiday",
+    "description": "オリエンテーション予備日"
+  },
+  {
+    "id": 405,
+    "date": "2026-04-29",
+    "type": "PublicHoliday",
+    "description": "昭和の日"
+  },
+  {
+    "id": 406,
+    "date": "2026-04-30",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Wednesday"
+  },
+  {
+    "id": 407,
+    "date": "2026-05-03",
+    "type": "PublicHoliday",
+    "description": "憲法記念日"
+  },
+  {
+    "id": 408,
+    "date": "2026-05-04",
+    "type": "PublicHoliday",
+    "description": "みどりの日"
+  },
+  {
+    "id": 409,
+    "date": "2026-05-05",
+    "type": "PublicHoliday",
+    "description": "こどもの日"
+  },
+  {
+    "id": 410,
+    "date": "2026-05-06",
+    "type": "PublicHoliday",
+    "description": "憲法記念日 振替休日"
+  },
+  {
+    "id": 411,
+    "date": "2026-05-08",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "id": 412,
+    "date": "2026-05-16",
+    "type": "Other",
+    "description": "春季スポーツ・デー"
+  },
+  {
+    "id": 413,
+    "date": "2026-05-17",
+    "type": "Other",
+    "description": "春季スポーツ・デー"
+  },
+  {
+    "id": 414,
+    "date": "2026-05-25",
+    "type": "Other",
+    "description": "春Aモジュール後予備日"
+  },
+  {
+    "id": 415,
+    "date": "2026-06-30",
+    "type": "Other",
+    "description": "春Bモジュール後予備日"
+  },
+  {
+    "id": 416,
+    "date": "2026-07-01",
+    "type": "Other",
+    "description": "春Bモジュール後予備日"
+  },
+  {
+    "id": 417,
+    "date": "2026-07-11",
+    "type": "Other",
+    "description": "学群編入学試験"
+  },
+  {
+    "id": 418,
+    "date": "2026-07-12",
+    "type": "Other",
+    "description": "学群編入学試験"
+  },
+  {
+    "id": 419,
+    "date": "2026-07-20",
+    "type": "PublicHoliday",
+    "description": "海の日"
+  },
+  {
+    "id": 420,
+    "date": "2026-07-23",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "id": 421,
+    "date": "2026-08-07",
+    "type": "Other",
+    "description": "春Cモジュール後予備日"
+  },
+  {
+    "id": 422,
+    "date": "2026-09-25",
+    "type": "Other",
+    "description": "卒業式/学位記授与式"
+  },
+  {
+    "id": 423,
+    "date": "2026-09-30",
+    "type": "Other",
+    "description": "秋学期入学式"
+  },
+  {
+    "id": 424,
+    "date": "2026-10-12",
+    "type": "PublicHoliday",
+    "description": "スポーツの日"
+  },
+  {
+    "id": 425,
+    "date": "2026-10-15",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "id": 426,
+    "date": "2026-10-30",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "id": 427,
+    "date": "2026-10-31",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "id": 428,
+    "date": "2026-11-01",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "id": 429,
+    "date": "2026-11-02",
+    "type": "Holiday",
+    "description": "臨時休講"
+  },
+  {
+    "id": 430,
+    "date": "2026-11-03",
+    "type": "PublicHoliday",
+    "description": "文化の日"
+  },
+  {
+    "id": 431,
+    "date": "2026-11-11",
+    "type": "Other",
+    "description": "秋Aモジュール後予備日"
+  },
+  {
+    "id": 432,
+    "date": "2026-11-14",
+    "type": "Other",
+    "description": "秋季スポーツ・デー"
+  },
+  {
+    "id": 433,
+    "date": "2026-11-15",
+    "type": "Other",
+    "description": "秋季スポーツ・デー"
+  },
+  {
+    "id": 434,
+    "date": "2026-11-23",
+    "type": "PublicHoliday",
+    "description": "勤労感謝の日"
+  },
+  {
+    "id": 435,
+    "date": "2026-11-24",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Wednesday"
+  },
+  {
+    "id": 436,
+    "date": "2026-11-25",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "id": 437,
+    "date": "2026-11-26",
+    "type": "Holiday",
+    "description": "推薦入試"
+  },
+  {
+    "id": 438,
+    "date": "2026-11-27",
+    "type": "Holiday",
+    "description": "推薦入試"
+  },
+  {
+    "id": 439,
+    "date": "2026-12-23",
+    "type": "Other",
+    "description": "秋Bモジュール後予備日"
+  },
+  {
+    "id": 440,
+    "date": "2026-12-24",
+    "type": "Other",
+    "description": "秋Bモジュール後予備日"
+  },
+  {
+    "id": 441,
+    "date": "2027-01-11",
+    "type": "PublicHoliday",
+    "description": "成人の日"
+  },
+  {
+    "id": 442,
+    "date": "2027-01-13",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "id": 443,
+    "date": "2027-01-15",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "id": 444,
+    "date": "2027-01-16",
+    "type": "Other",
+    "description": "大学入学共通テスト"
+  },
+  {
+    "id": 445,
+    "date": "2027-01-17",
+    "type": "Other",
+    "description": "大学入学共通テスト"
+  },
+  {
+    "id": 446,
+    "date": "2027-01-18",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "id": 447,
+    "date": "2027-02-11",
+    "type": "PublicHoliday",
+    "description": "建国記念の日"
+  },
+  {
+    "id": 448,
+    "date": "2027-02-16",
+    "type": "Other",
+    "description": "秋Cモジュール後予備日"
+  },
+  {
+    "id": 449,
+    "date": "2027-02-25",
+    "type": "Other",
+    "description": "個別学力検査等前期日程"
+  },
+  {
+    "id": 450,
+    "date": "2027-02-26",
+    "type": "Other",
+    "description": "個別学力検査等前期日程"
+  },
+  {
+    "id": 451,
+    "date": "2027-03-10",
+    "type": "Other",
+    "description": "医学類卒業日"
+  },
+  {
+    "id": 452,
+    "date": "2027-03-12",
+    "type": "Other",
+    "description": "個別学力検査等後期日程"
+  },
+  {
+    "id": 453,
+    "date": "2027-03-25",
+    "type": "Other",
+    "description": "卒業式/学位記授与式"
   }
 ]

--- a/back/module/schoolcalendar/data/event_gen.json
+++ b/back/module/schoolcalendar/data/event_gen.json
@@ -2428,342 +2428,336 @@
   },
   {
     "id": 398,
-    "date": "2026-04-07",
-    "type": "Holiday",
-    "description": "学群1年次TOEIC IPテスト"
-  },
-  {
-    "id": 399,
     "date": "2026-04-06",
     "type": "Holiday",
     "description": "新入生オリエンテーション"
   },
   {
-    "id": 400,
+    "id": 399,
     "date": "2026-04-07",
     "type": "Holiday",
-    "description": "新入生オリエンテーション"
+    "description": "学群1年次TOEIC IPテスト"
   },
   {
-    "id": 401,
+    "id": 400,
     "date": "2026-04-08",
     "type": "Holiday",
     "description": "新入生オリエンテーション"
   },
   {
-    "id": 402,
+    "id": 401,
     "date": "2026-04-09",
     "type": "Holiday",
     "description": "オリエンテーション予備日"
   },
   {
-    "id": 403,
+    "id": 402,
     "date": "2026-04-10",
     "type": "Holiday",
     "description": "新入生歓迎祭"
   },
   {
-    "id": 404,
+    "id": 403,
     "date": "2026-04-13",
     "type": "Holiday",
     "description": "オリエンテーション予備日"
   },
   {
-    "id": 405,
+    "id": 404,
     "date": "2026-04-29",
     "type": "PublicHoliday",
     "description": "昭和の日"
   },
   {
-    "id": 406,
+    "id": 405,
     "date": "2026-04-30",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Wednesday"
   },
   {
-    "id": 407,
+    "id": 406,
     "date": "2026-05-03",
     "type": "PublicHoliday",
     "description": "憲法記念日"
   },
   {
-    "id": 408,
+    "id": 407,
     "date": "2026-05-04",
     "type": "PublicHoliday",
     "description": "みどりの日"
   },
   {
-    "id": 409,
+    "id": 408,
     "date": "2026-05-05",
     "type": "PublicHoliday",
     "description": "こどもの日"
   },
   {
-    "id": 410,
+    "id": 409,
     "date": "2026-05-06",
     "type": "PublicHoliday",
     "description": "憲法記念日 振替休日"
   },
   {
-    "id": 411,
+    "id": 410,
     "date": "2026-05-08",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Monday"
   },
   {
-    "id": 412,
+    "id": 411,
     "date": "2026-05-16",
     "type": "Other",
     "description": "春季スポーツ・デー"
   },
   {
-    "id": 413,
+    "id": 412,
     "date": "2026-05-17",
     "type": "Other",
     "description": "春季スポーツ・デー"
   },
   {
-    "id": 414,
+    "id": 413,
     "date": "2026-05-25",
     "type": "Other",
     "description": "春Aモジュール後予備日"
   },
   {
-    "id": 415,
+    "id": 414,
     "date": "2026-06-30",
     "type": "Other",
     "description": "春Bモジュール後予備日"
   },
   {
-    "id": 416,
+    "id": 415,
     "date": "2026-07-01",
     "type": "Other",
     "description": "春Bモジュール後予備日"
   },
   {
-    "id": 417,
+    "id": 416,
     "date": "2026-07-11",
     "type": "Other",
     "description": "学群編入学試験"
   },
   {
-    "id": 418,
+    "id": 417,
     "date": "2026-07-12",
     "type": "Other",
     "description": "学群編入学試験"
   },
   {
-    "id": 419,
+    "id": 418,
     "date": "2026-07-20",
     "type": "PublicHoliday",
     "description": "海の日"
   },
   {
-    "id": 420,
+    "id": 419,
     "date": "2026-07-23",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Monday"
   },
   {
-    "id": 421,
+    "id": 420,
     "date": "2026-08-07",
     "type": "Other",
     "description": "春Cモジュール後予備日"
   },
   {
-    "id": 422,
+    "id": 421,
     "date": "2026-09-25",
     "type": "Other",
     "description": "卒業式/学位記授与式"
   },
   {
-    "id": 423,
+    "id": 422,
     "date": "2026-09-30",
     "type": "Other",
     "description": "秋学期入学式"
   },
   {
-    "id": 424,
+    "id": 423,
     "date": "2026-10-12",
     "type": "PublicHoliday",
     "description": "スポーツの日"
   },
   {
-    "id": 425,
+    "id": 424,
     "date": "2026-10-15",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Monday"
   },
   {
-    "id": 426,
+    "id": 425,
     "date": "2026-10-30",
     "type": "Holiday",
     "description": "学園祭"
   },
   {
-    "id": 427,
+    "id": 426,
     "date": "2026-10-31",
     "type": "Holiday",
     "description": "学園祭"
   },
   {
-    "id": 428,
+    "id": 427,
     "date": "2026-11-01",
     "type": "Holiday",
     "description": "学園祭"
   },
   {
-    "id": 429,
+    "id": 428,
     "date": "2026-11-02",
     "type": "Holiday",
     "description": "臨時休講"
   },
   {
-    "id": 430,
+    "id": 429,
     "date": "2026-11-03",
     "type": "PublicHoliday",
     "description": "文化の日"
   },
   {
-    "id": 431,
+    "id": 430,
     "date": "2026-11-11",
     "type": "Other",
     "description": "秋Aモジュール後予備日"
   },
   {
-    "id": 432,
+    "id": 431,
     "date": "2026-11-14",
     "type": "Other",
     "description": "秋季スポーツ・デー"
   },
   {
-    "id": 433,
+    "id": 432,
     "date": "2026-11-15",
     "type": "Other",
     "description": "秋季スポーツ・デー"
   },
   {
-    "id": 434,
+    "id": 433,
     "date": "2026-11-23",
     "type": "PublicHoliday",
     "description": "勤労感謝の日"
   },
   {
-    "id": 435,
+    "id": 434,
     "date": "2026-11-24",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Wednesday"
   },
   {
-    "id": 436,
+    "id": 435,
     "date": "2026-11-25",
     "type": "Holiday",
     "description": "臨時休業"
   },
   {
-    "id": 437,
+    "id": 436,
     "date": "2026-11-26",
     "type": "Holiday",
     "description": "推薦入試"
   },
   {
-    "id": 438,
+    "id": 437,
     "date": "2026-11-27",
     "type": "Holiday",
     "description": "推薦入試"
   },
   {
-    "id": 439,
+    "id": 438,
     "date": "2026-12-23",
     "type": "Other",
     "description": "秋Bモジュール後予備日"
   },
   {
-    "id": 440,
+    "id": 439,
     "date": "2026-12-24",
     "type": "Other",
     "description": "秋Bモジュール後予備日"
   },
   {
-    "id": 441,
+    "id": 440,
     "date": "2027-01-11",
     "type": "PublicHoliday",
     "description": "成人の日"
   },
   {
-    "id": 442,
+    "id": 441,
     "date": "2027-01-13",
     "type": "SubstituteDay",
     "description": "",
     "changeTo": "Monday"
   },
   {
-    "id": 443,
+    "id": 442,
     "date": "2027-01-15",
     "type": "Holiday",
     "description": "臨時休業"
   },
   {
-    "id": 444,
+    "id": 443,
     "date": "2027-01-16",
     "type": "Other",
     "description": "大学入学共通テスト"
   },
   {
-    "id": 445,
+    "id": 444,
     "date": "2027-01-17",
     "type": "Other",
     "description": "大学入学共通テスト"
   },
   {
-    "id": 446,
+    "id": 445,
     "date": "2027-01-18",
     "type": "Holiday",
     "description": "臨時休業"
   },
   {
-    "id": 447,
+    "id": 446,
     "date": "2027-02-11",
     "type": "PublicHoliday",
     "description": "建国記念の日"
   },
   {
-    "id": 448,
+    "id": 447,
     "date": "2027-02-16",
     "type": "Other",
     "description": "秋Cモジュール後予備日"
   },
   {
-    "id": 449,
+    "id": 448,
     "date": "2027-02-25",
     "type": "Other",
     "description": "個別学力検査等前期日程"
   },
   {
-    "id": 450,
+    "id": 449,
     "date": "2027-02-26",
     "type": "Other",
     "description": "個別学力検査等前期日程"
   },
   {
-    "id": 451,
+    "id": 450,
     "date": "2027-03-10",
     "type": "Other",
     "description": "医学類卒業日"
   },
   {
-    "id": 452,
+    "id": 451,
     "date": "2027-03-12",
     "type": "Other",
     "description": "個別学力検査等後期日程"
   },
   {
-    "id": 453,
+    "id": 452,
     "date": "2027-03-25",
     "type": "Other",
     "description": "卒業式/学位記授与式"

--- a/back/module/schoolcalendar/data/module_detail_gen.json
+++ b/back/module/schoolcalendar/data/module_detail_gen.json
@@ -418,5 +418,75 @@
     "module": "SpringVacation",
     "start": "2026-02-17",
     "end": "2026-03-31"
+  },
+  {
+    "id": 61,
+    "year": 2026,
+    "module": "SpringVacation",
+    "start": "2026-04-01",
+    "end": "2026-04-05"
+  },
+  {
+    "id": 62,
+    "year": 2026,
+    "module": "SpringA",
+    "start": "2026-04-06",
+    "end": "2026-05-25"
+  },
+  {
+    "id": 63,
+    "year": 2026,
+    "module": "SpringB",
+    "start": "2026-05-26",
+    "end": "2026-07-01"
+  },
+  {
+    "id": 64,
+    "year": 2026,
+    "module": "SpringC",
+    "start": "2026-07-02",
+    "end": "2026-08-07"
+  },
+  {
+    "id": 65,
+    "year": 2026,
+    "module": "SummerVacation",
+    "start": "2026-08-08",
+    "end": "2026-09-30"
+  },
+  {
+    "id": 66,
+    "year": 2026,
+    "module": "FallA",
+    "start": "2026-10-01",
+    "end": "2026-11-11"
+  },
+  {
+    "id": 67,
+    "year": 2026,
+    "module": "FallB",
+    "start": "2026-11-12",
+    "end": "2026-12-24"
+  },
+  {
+    "id": 68,
+    "year": 2026,
+    "module": "WinterVacation",
+    "start": "2026-12-25",
+    "end": "2027-01-05"
+  },
+  {
+    "id": 69,
+    "year": 2026,
+    "module": "FallC",
+    "start": "2027-01-06",
+    "end": "2027-02-16"
+  },
+  {
+    "id": 70,
+    "year": 2026,
+    "module": "SpringVacation",
+    "start": "2027-02-17",
+    "end": "2027-03-31"
   }
 ]

--- a/codegen/schoolcalendar/event/2026.json
+++ b/codegen/schoolcalendar/event/2026.json
@@ -1,0 +1,293 @@
+[
+  {
+    "date": "2026-04-06",
+    "type": "Holiday",
+    "description": "入学式"
+  },
+  {
+    "date": "2026-04-07",
+    "type": "Holiday",
+    "description": "学群1年次TOEIC IPテスト"
+  },
+  {
+    "date": "2026-04-06",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "date": "2026-04-07",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "date": "2026-04-08",
+    "type": "Holiday",
+    "description": "新入生オリエンテーション"
+  },
+  {
+    "date": "2026-04-09",
+    "type": "Holiday",
+    "description": "オリエンテーション予備日"
+  },
+  {
+    "date": "2026-04-10",
+    "type": "Holiday",
+    "description": "新入生歓迎祭"
+  },
+  {
+    "date": "2026-04-13",
+    "type": "Holiday",
+    "description": "オリエンテーション予備日"
+  },
+  {
+    "date": "2026-04-29",
+    "type": "PublicHoliday",
+    "description": "昭和の日"
+  },
+  {
+    "date": "2026-04-30",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Wednesday"
+  },
+  {
+    "date": "2026-05-03",
+    "type": "PublicHoliday",
+    "description": "憲法記念日"
+  },
+  {
+    "date": "2026-05-04",
+    "type": "PublicHoliday",
+    "description": "みどりの日"
+  },
+  {
+    "date": "2026-05-05",
+    "type": "PublicHoliday",
+    "description": "こどもの日"
+  },
+  {
+    "date": "2026-05-06",
+    "type": "PublicHoliday",
+    "description": "憲法記念日 振替休日"
+  },
+  {
+    "date": "2026-05-08",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "date": "2026-05-16",
+    "type": "Other",
+    "description": "春季スポーツ・デー"
+  },
+  {
+    "date": "2026-05-17",
+    "type": "Other",
+    "description": "春季スポーツ・デー"
+  },
+  {
+    "date": "2026-05-25",
+    "type": "Other",
+    "description": "春Aモジュール後予備日"
+  },
+  {
+    "date": "2026-06-30",
+    "type": "Other",
+    "description": "春Bモジュール後予備日"
+  },
+  {
+    "date": "2026-07-01",
+    "type": "Other",
+    "description": "春Bモジュール後予備日"
+  },
+  {
+    "date": "2026-07-11",
+    "type": "Other",
+    "description": "学群編入学試験"
+  },
+  {
+    "date": "2026-07-12",
+    "type": "Other",
+    "description": "学群編入学試験"
+  },
+  {
+    "date": "2026-07-20",
+    "type": "PublicHoliday",
+    "description": "海の日"
+  },
+  {
+    "date": "2026-07-23",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "date": "2026-08-07",
+    "type": "Other",
+    "description": "春Cモジュール後予備日"
+  },
+  {
+    "date": "2026-09-25",
+    "type": "Other",
+    "description": "卒業式/学位記授与式"
+  },
+  {
+    "date": "2026-09-30",
+    "type": "Other",
+    "description": "秋学期入学式"
+  },
+  {
+    "date": "2026-10-12",
+    "type": "PublicHoliday",
+    "description": "スポーツの日"
+  },
+  {
+    "date": "2026-10-15",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "date": "2026-10-30",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "date": "2026-10-31",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "date": "2026-11-01",
+    "type": "Holiday",
+    "description": "学園祭"
+  },
+  {
+    "date": "2026-11-02",
+    "type": "Holiday",
+    "description": "臨時休講"
+  },
+  {
+    "date": "2026-11-03",
+    "type": "PublicHoliday",
+    "description": "文化の日"
+  },
+  {
+    "date": "2026-11-11",
+    "type": "Other",
+    "description": "秋Aモジュール後予備日"
+  },
+  {
+    "date": "2026-11-14",
+    "type": "Other",
+    "description": "秋季スポーツ・デー"
+  },
+  {
+    "date": "2026-11-15",
+    "type": "Other",
+    "description": "秋季スポーツ・デー"
+  },
+  {
+    "date": "2026-11-23",
+    "type": "PublicHoliday",
+    "description": "勤労感謝の日"
+  },
+  {
+    "date": "2026-11-24",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Wednesday"
+  },
+  {
+    "date": "2026-11-25",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "date": "2026-11-26",
+    "type": "Holiday",
+    "description": "推薦入試"
+  },
+  {
+    "date": "2026-11-27",
+    "type": "Holiday",
+    "description": "推薦入試"
+  },
+  {
+    "date": "2026-12-23",
+    "type": "Other",
+    "description": "秋Bモジュール後予備日"
+  },
+  {
+    "date": "2026-12-24",
+    "type": "Other",
+    "description": "秋Bモジュール後予備日"
+  },
+  {
+    "date": "2027-01-11",
+    "type": "PublicHoliday",
+    "description": "成人の日"
+  },
+  {
+    "date": "2027-01-13",
+    "type": "SubstituteDay",
+    "description": "",
+    "changeTo": "Monday"
+  },
+  {
+    "date": "2027-01-15",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "date": "2027-01-16",
+    "type": "Other",
+    "description": "大学入学共通テスト"
+  },
+  {
+    "date": "2027-01-17",
+    "type": "Other",
+    "description": "大学入学共通テスト"
+  },
+  {
+    "date": "2027-01-18",
+    "type": "Holiday",
+    "description": "臨時休業"
+  },
+  {
+    "date": "2027-02-11",
+    "type": "PublicHoliday",
+    "description": "建国記念の日"
+  },
+  {
+    "date": "2027-02-16",
+    "type": "Other",
+    "description": "秋Cモジュール後予備日"
+  },
+  {
+    "date": "2027-02-25",
+    "type": "Other",
+    "description": "個別学力検査等前期日程"
+  },
+  {
+    "date": "2027-02-26",
+    "type": "Other",
+    "description": "個別学力検査等前期日程"
+  },
+  {
+    "date": "2027-03-10",
+    "type": "Other",
+    "description": "医学類卒業日"
+  },
+  {
+    "date": "2027-03-12",
+    "type": "Other",
+    "description": "個別学力検査等後期日程"
+  },
+  {
+    "date": "2027-03-25",
+    "type": "Other",
+    "description": "卒業式/学位記授与式"
+  }
+]

--- a/codegen/schoolcalendar/event/2026.json
+++ b/codegen/schoolcalendar/event/2026.json
@@ -5,11 +5,6 @@
     "description": "入学式"
   },
   {
-    "date": "2026-04-07",
-    "type": "Holiday",
-    "description": "学群1年次TOEIC IPテスト"
-  },
-  {
     "date": "2026-04-06",
     "type": "Holiday",
     "description": "新入生オリエンテーション"
@@ -17,7 +12,7 @@
   {
     "date": "2026-04-07",
     "type": "Holiday",
-    "description": "新入生オリエンテーション"
+    "description": "学群1年次TOEIC IPテスト"
   },
   {
     "date": "2026-04-08",

--- a/codegen/schoolcalendar/module_detail/2026.json
+++ b/codegen/schoolcalendar/module_detail/2026.json
@@ -1,0 +1,62 @@
+[
+  {
+    "year": 2026,
+    "module": "SpringVacation",
+    "start": "2026-04-01",
+    "end": "2026-04-05"
+  },
+  {
+    "year": 2026,
+    "module": "SpringA",
+    "start": "2026-04-06",
+    "end": "2026-05-25"
+  },
+  {
+    "year": 2026,
+    "module": "SpringB",
+    "start": "2026-05-26",
+    "end": "2026-07-01"
+  },
+  {
+    "year": 2026,
+    "module": "SpringC",
+    "start": "2026-07-02",
+    "end": "2026-08-07"
+  },
+  {
+    "year": 2026,
+    "module": "SummerVacation",
+    "start": "2026-08-08",
+    "end": "2026-09-30"
+  },
+  {
+    "year": 2026,
+    "module": "FallA",
+    "start": "2026-10-01",
+    "end": "2026-11-11"
+  },
+  {
+    "year": 2026,
+    "module": "FallB",
+    "start": "2026-11-12",
+    "end": "2026-12-24"
+  },
+  {
+    "year": 2026,
+    "module": "WinterVacation",
+    "start": "2026-12-25",
+    "end": "2027-01-05"
+  },
+  {
+    "year": 2026,
+    "module": "FallC",
+    "start": "2027-01-06",
+    "end": "2027-02-16"
+  },
+  {
+    "year": 2026,
+    "module": "SpringVacation",
+    "start": "2027-02-17",
+    "end": "2027-03-31"
+  }
+]


### PR DESCRIPTION
- https://www.tsukuba.ac.jp/campuslife/calendar-school/
- https://www.tsukuba.ac.jp/campuslife/calendar-school/pdf/2026-undergrad-grad-tsukuba.pdf
をベースに作成