### PR TITLE
[back] Goのバージョンを1.26に上げる

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.6
+ARG GO_VERSION=1.26.2
 FROM golang:${GO_VERSION} AS base
 WORKDIR /usr/src/twin-te/back
 

--- a/back/base/pointer.go
+++ b/back/base/pointer.go
@@ -1,6 +1,6 @@
 package base
 
-import "golang.org/x/exp/slices"
+import "slices"
 
 func ToPtrWithErr[T any](x T, err error) (*T, error) {
 	if err != nil {

--- a/back/go.mod
+++ b/back/go.mod
@@ -1,6 +1,6 @@
 module github.com/twin-te/twin-te/back
 
-go 1.24.6
+go 1.26.2
 
 require (
 	cloud.google.com/go v0.116.0

--- a/back/go.mod
+++ b/back/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/samber/lo v1.39.0
 	github.com/samber/mo v1.11.0
-	github.com/spf13/cobra v1.9.1
+	github.com/spf13/cobra v1.10.2
 	github.com/stripe/stripe-go/v76 v76.25.0
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476
 	golang.org/x/oauth2 v0.30.0
@@ -64,6 +64,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d // indirect
+	github.com/derekparker/trie/v3 v3.2.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
@@ -81,7 +82,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fullstorydev/grpcurl v1.9.3 // indirect
 	github.com/go-chi/chi/v5 v5.2.1 // indirect
-	github.com/go-delve/delve v1.25.0 // indirect
+	github.com/go-delve/delve v1.26.1 // indirect
 	github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -143,7 +144,7 @@ require (
 	github.com/spf13/cast v1.8.0 // indirect
 	github.com/spf13/cobra-cli v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/spf13/viper v1.10.1 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
@@ -168,6 +169,7 @@ require (
 	go.uber.org/mock v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250218142911-aa4b98e5adaa // indirect

--- a/back/go.sum
+++ b/back/go.sum
@@ -210,6 +210,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d h1:hUWoLdw5kvo2xCsqlsIBMvWUc1QCSsCYD2J2+Fg6YoU=
 github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d/go.mod h1:C7Es+DLenIpPc9J6IYw4jrK0h7S9bKj4DNl8+KxGEXU=
+github.com/derekparker/trie/v3 v3.2.0 h1:fET3Qbp9xSB7yc7tz6Y2GKMNl0SycYFo3cmiRI3Gpf0=
+github.com/derekparker/trie/v3 v3.2.0/go.mod h1:P94lW0LPgiaMgKAEQD59IDZD2jMK9paKok8Nli/nQbE=
 github.com/disintegration/gift v1.2.1 h1:Y005a1X4Z7Uc+0gLpSAsKhWi4qLtsdEcMIbbdvdZ6pc=
 github.com/disintegration/gift v1.2.1/go.mod h1:Jh2i7f7Q2BM7Ezno3PhfezbR1xpUg9dUg3/RlKGr4HI=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -280,6 +282,8 @@ github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-delve/delve v1.25.0 h1:JN2S3iVptvayUS2w+d0UEPmijgkodW1AFM4I8UViHGE=
 github.com/go-delve/delve v1.25.0/go.mod h1:kJk12wo6PqzWknTP6M+Pg3/CrNhFMZvNq1iHESKkhv8=
+github.com/go-delve/delve v1.26.1 h1:V1F0hzAjXCpsBP+I/E6fVUTLC/ZBSs1YWUb8cTtIWFE=
+github.com/go-delve/delve v1.26.1/go.mod h1:Ua/k2AAu4cLrUXGSRVH1b2Nzq2aCK188b9EYlAojlz4=
 github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62 h1:IGtvsNyIuRjl04XAOFGACozgUD7A82UffYxZt4DWbvA=
 github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
@@ -688,6 +692,8 @@ github.com/spf13/cast v1.8.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/cobra-cli v1.3.0 h1:Y/qy0X40kDT+k7PCyBQrsjh/qOf9t/ZVScbn0OyZD84=
 github.com/spf13/cobra-cli v1.3.0/go.mod h1:zq1KeHo/9SQm1tNdbJhwVDd9bVpokbQwuG6MR0TFCdE=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
@@ -695,6 +701,8 @@ github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=
 github.com/spf13/viper v1.10.1 h1:nuJZuYpG7gTj/XqiUwg8bA0cp1+M2mC3J4g5luUYBKk=
 github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8qy1rU=
@@ -804,6 +812,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/arch v0.11.0 h1:KXV8WWKCXm6tRpLirl2szsO5j/oOODwZf4hATmGVNs4=
 golang.org/x/arch v0.11.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/back/go.sum
+++ b/back/go.sum
@@ -717,8 +717,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stripe/stripe-go/v76 v76.18.0 h1:MYUgecXPoUDJ36hjKtc8h2fzpj0MpRBrN9KGCULFTbg=
-github.com/stripe/stripe-go/v76 v76.18.0/go.mod h1:rw1MxjlAKKcZ+3FOXgTHgwiOa2ya6CPq6ykpJ0Q6Po4=
 github.com/stripe/stripe-go/v76 v76.25.0 h1:kmDoOTvdQSTQssQzWZQQkgbAR2Q8eXdMWbN/ylNalWA=
 github.com/stripe/stripe-go/v76 v76.25.0/go.mod h1:rw1MxjlAKKcZ+3FOXgTHgwiOa2ya6CPq6ykpJ0Q6Po4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=

--- a/back/handler/api/v4/rpc/announcement/v1/conv/announcement.go
+++ b/back/handler/api/v4/rpc/announcement/v1/conv/announcement.go
@@ -21,7 +21,7 @@ func ToPBAnnouncement(announcement *announcementdomain.Announcement, idToReadFla
 		Title:       announcement.Title.String(),
 		Content:     announcement.Content.String(),
 		PublishedAt: sharedconv.ToPBRFC3339DateTime(announcement.PublishedAt),
-		IsRead:      lo.Ternary(idToReadFlag == nil, nil, lo.ToPtr(idToReadFlag[announcement.ID])),
+		IsRead:      lo.Ternary(idToReadFlag == nil, nil, new(idToReadFlag[announcement.ID])),
 	}
 
 	return pbAnnouncement, nil

--- a/back/handler/auth/v4/apple.go
+++ b/back/handler/auth/v4/apple.go
@@ -55,7 +55,7 @@ func getAppleSocialID(ctx context.Context, code string) (socialID authdomain.Soc
 	// cf. https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#3383769
 	idToken, err := jwt.Parse(
 		idTokenString,
-		func(t *jwt.Token) (interface{}, error) {
+		func(t *jwt.Token) (any, error) {
 			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 				return nil, fmt.Errorf("unexpected signing method: %+v", t.Header["alg"])
 			}

--- a/back/handler/calendar/v1beta/school_calendar.go
+++ b/back/handler/calendar/v1beta/school_calendar.go
@@ -2,6 +2,7 @@ package calendarv1beta
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 
@@ -20,10 +21,8 @@ type Module struct {
 }
 
 func (m Module) addException(weekday time.Weekday, date civil.Date) {
-	for _, d := range m.Exceptions[weekday] {
-		if d == date {
-			return // Already exists
-		}
+	if slices.Contains(m.Exceptions[weekday], date) {
+		return // Already exists
 	}
 	m.Exceptions[weekday] = append(m.Exceptions[weekday], date)
 }

--- a/back/module/announcement/domain/announcement.go
+++ b/back/module/announcement/domain/announcement.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/twin-te/twin-te/back/base"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
@@ -47,7 +46,7 @@ type Announcement struct {
 }
 
 func (a *Announcement) Clone() *Announcement {
-	ret := lo.ToPtr(*a)
+	ret := new(*a)
 	ret.Tags = base.CopySlice(a.Tags)
 	return ret
 }

--- a/back/module/auth/domain/user.go
+++ b/back/module/auth/domain/user.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/twin-te/twin-te/back/apperr"
 	"github.com/twin-te/twin-te/back/base"
@@ -24,7 +23,7 @@ type User struct {
 }
 
 func (u *User) Clone() *User {
-	ret := lo.ToPtr(*u)
+	ret := new(*u)
 	ret.Authentications = base.CopySlice(u.Authentications)
 	return ret
 }

--- a/back/module/donation/adapter/integrator/checkout_session.go
+++ b/back/module/donation/adapter/integrator/checkout_session.go
@@ -25,25 +25,25 @@ func (i *impl) CreateOneTimeCheckoutSession(ctx context.Context, paymentUserID m
 			Context: ctx,
 		},
 		PaymentMethodTypes: stripe.StringSlice([]string{"card"}),
-		SubmitType:         stripe.String("donate"),
+		SubmitType:         new("donate"),
 		Customer:           base.OptionMapByString(paymentUserID).ToPointer(),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
 				Quantity: stripe.Int64(1),
 				PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
 					ProductData: &stripe.CheckoutSessionLineItemPriceDataProductDataParams{
-						Name:        stripe.String("Twin:te寄付"),
-						Description: stripe.String("寄付いただいたお金はTwin:teの運用や開発に使用します"),
+						Name:        new("Twin:te寄付"),
+						Description: new("寄付いただいたお金はTwin:teの運用や開発に使用します"),
 						Images:      stripe.StringSlice([]string{"https://www.twinte.net/ogp.jpg"}),
 					},
-					Currency:   stripe.String("jpy"),
-					UnitAmount: stripe.Int64(int64(amount)),
+					Currency:   new("jpy"),
+					UnitAmount: new(int64(amount)),
 				},
 			},
 		},
 		Mode:       stripe.String(string(stripe.CheckoutSessionModePayment)),
-		SuccessURL: stripe.String(fmt.Sprintf("%s?type=onetime&amount=%d", appenv.STRIPE_CHECKOUT_SUCCESS_URL, amount)),
-		CancelURL:  stripe.String(appenv.STRIPE_CHECKOUT_CANCEL_URL),
+		SuccessURL: new(fmt.Sprintf("%s?type=onetime&amount=%d", appenv.STRIPE_CHECKOUT_SUCCESS_URL, amount)),
+		CancelURL:  new(appenv.STRIPE_CHECKOUT_CANCEL_URL),
 	}
 
 	s, err := session.New(params)
@@ -60,16 +60,16 @@ func (i *impl) CreateSubscriptionCheckoutSession(ctx context.Context, paymentUse
 			Context: ctx,
 		},
 		PaymentMethodTypes: stripe.StringSlice([]string{"card"}),
-		Customer:           stripe.String(paymentUserID.String()),
+		Customer:           new(paymentUserID.String()),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
-				Price:    stripe.String(subscriptionPlanID.String()),
+				Price:    new(subscriptionPlanID.String()),
 				Quantity: stripe.Int64(1),
 			},
 		},
 		Mode:       stripe.String(string(stripe.CheckoutSessionModeSubscription)),
-		SuccessURL: stripe.String(fmt.Sprintf("%s?type=subscription&plan_id=%s", appenv.STRIPE_CHECKOUT_SUCCESS_URL, subscriptionPlanID)),
-		CancelURL:  stripe.String(appenv.STRIPE_CHECKOUT_CANCEL_URL),
+		SuccessURL: new(fmt.Sprintf("%s?type=subscription&plan_id=%s", appenv.STRIPE_CHECKOUT_SUCCESS_URL, subscriptionPlanID)),
+		CancelURL:  new(appenv.STRIPE_CHECKOUT_CANCEL_URL),
 	}
 
 	s, err := session.New(params)

--- a/back/module/donation/adapter/integrator/checkout_session.go
+++ b/back/module/donation/adapter/integrator/checkout_session.go
@@ -25,25 +25,25 @@ func (i *impl) CreateOneTimeCheckoutSession(ctx context.Context, paymentUserID m
 			Context: ctx,
 		},
 		PaymentMethodTypes: stripe.StringSlice([]string{"card"}),
-		SubmitType:         new("donate"),
+		SubmitType:         stripe.String("donate"),
 		Customer:           base.OptionMapByString(paymentUserID).ToPointer(),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
 				Quantity: stripe.Int64(1),
 				PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
 					ProductData: &stripe.CheckoutSessionLineItemPriceDataProductDataParams{
-						Name:        new("Twin:te寄付"),
-						Description: new("寄付いただいたお金はTwin:teの運用や開発に使用します"),
+						Name:        stripe.String("Twin:te寄付"),
+						Description: stripe.String("寄付いただいたお金はTwin:teの運用や開発に使用します"),
 						Images:      stripe.StringSlice([]string{"https://www.twinte.net/ogp.jpg"}),
 					},
-					Currency:   new("jpy"),
-					UnitAmount: new(int64(amount)),
+					Currency:   stripe.String("jpy"),
+					UnitAmount: stripe.Int64(int64(amount)),
 				},
 			},
 		},
 		Mode:       stripe.String(string(stripe.CheckoutSessionModePayment)),
-		SuccessURL: new(fmt.Sprintf("%s?type=onetime&amount=%d", appenv.STRIPE_CHECKOUT_SUCCESS_URL, amount)),
-		CancelURL:  new(appenv.STRIPE_CHECKOUT_CANCEL_URL),
+		SuccessURL: stripe.String(fmt.Sprintf("%s?type=onetime&amount=%d", appenv.STRIPE_CHECKOUT_SUCCESS_URL, amount)),
+		CancelURL:  stripe.String(appenv.STRIPE_CHECKOUT_CANCEL_URL),
 	}
 
 	s, err := session.New(params)
@@ -60,16 +60,16 @@ func (i *impl) CreateSubscriptionCheckoutSession(ctx context.Context, paymentUse
 			Context: ctx,
 		},
 		PaymentMethodTypes: stripe.StringSlice([]string{"card"}),
-		Customer:           new(paymentUserID.String()),
+		Customer:           stripe.String(paymentUserID.String()),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
-				Price:    new(subscriptionPlanID.String()),
+				Price:    stripe.String(subscriptionPlanID.String()),
 				Quantity: stripe.Int64(1),
 			},
 		},
 		Mode:       stripe.String(string(stripe.CheckoutSessionModeSubscription)),
-		SuccessURL: new(fmt.Sprintf("%s?type=subscription&plan_id=%s", appenv.STRIPE_CHECKOUT_SUCCESS_URL, subscriptionPlanID)),
-		CancelURL:  new(appenv.STRIPE_CHECKOUT_CANCEL_URL),
+		SuccessURL: stripe.String(fmt.Sprintf("%s?type=subscription&plan_id=%s", appenv.STRIPE_CHECKOUT_SUCCESS_URL, subscriptionPlanID)),
+		CancelURL:  stripe.String(appenv.STRIPE_CHECKOUT_CANCEL_URL),
 	}
 
 	s, err := session.New(params)

--- a/back/module/donation/adapter/integrator/subscription.go
+++ b/back/module/donation/adapter/integrator/subscription.go
@@ -27,8 +27,8 @@ func (i *impl) ListSubscriptions(ctx context.Context, paymentUserID idtype.Payme
 				Limit:         stripe.Int64(100),
 				StartingAfter: startingAfter,
 			},
-			Customer: stripe.String(paymentUserID.String()),
-			Status:   stripe.String("all"),
+			Customer: new(paymentUserID.String()),
+			Status:   new("all"),
 		})
 
 		if err := iter.Err(); err != nil {
@@ -95,7 +95,7 @@ func (i *impl) loadSubscriptionPlans() (err error) {
 				Limit:         stripe.Int64(100),
 				StartingAfter: startingAfter,
 			},
-			Active: stripe.Bool(true),
+			Active: new(true),
 		})
 
 		if err := iter.Err(); err != nil {

--- a/back/module/donation/adapter/integrator/subscription.go
+++ b/back/module/donation/adapter/integrator/subscription.go
@@ -27,8 +27,8 @@ func (i *impl) ListSubscriptions(ctx context.Context, paymentUserID idtype.Payme
 				Limit:         stripe.Int64(100),
 				StartingAfter: startingAfter,
 			},
-			Customer: new(paymentUserID.String()),
-			Status:   new("all"),
+			Customer: stripe.String(paymentUserID.String()),
+			Status:   stripe.String("all"),
 		})
 
 		if err := iter.Err(); err != nil {
@@ -95,7 +95,7 @@ func (i *impl) loadSubscriptionPlans() (err error) {
 				Limit:         stripe.Int64(100),
 				StartingAfter: startingAfter,
 			},
-			Active: new(true),
+			Active: stripe.Bool(true),
 		})
 
 		if err := iter.Err(); err != nil {

--- a/back/module/donation/domain/payment_user.go
+++ b/back/module/donation/domain/payment_user.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
@@ -38,7 +37,7 @@ type PaymentUser struct {
 }
 
 func (pu *PaymentUser) Clone() *PaymentUser {
-	ret := lo.ToPtr(*pu)
+	ret := new(*pu)
 	return ret
 }
 

--- a/back/module/donation/domain/subscription.go
+++ b/back/module/donation/domain/subscription.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 )
@@ -18,7 +17,7 @@ type SubscriptionPlan struct {
 }
 
 func (sp *SubscriptionPlan) Clone() *SubscriptionPlan {
-	ret := lo.ToPtr(*sp)
+	ret := new(*sp)
 	return ret
 }
 

--- a/back/module/donation/usecase/payment_user.go
+++ b/back/module/donation/usecase/payment_user.go
@@ -95,7 +95,6 @@ func (uc *impl) updateContributorsCache(ctx context.Context) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, paymentUser := range paymentUsers {
-		paymentUser := paymentUser
 		eg.Go(func() error {
 			select {
 			case <-ctx.Done():

--- a/back/module/schoolcalendar/data/loader.go
+++ b/back/module/schoolcalendar/data/loader.go
@@ -20,7 +20,7 @@ type jsonEvent struct {
 	Type        string            `json:"type"`
 	Date        string            `json:"date"`
 	Description string            `json:"description"`
-	ChangeTo    mo.Option[string] `json:"changeTo,omitempty"`
+	ChangeTo    mo.Option[string] `json:"changeTo"`
 }
 
 type jsonModuleDetail struct {

--- a/back/module/schoolcalendar/domain/event.go
+++ b/back/module/schoolcalendar/domain/event.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/twin-te/twin-te/back/base"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
@@ -91,7 +90,7 @@ func (e *Event) IsFallCExam() bool {
 }
 
 func (e *Event) Clone() *Event {
-	ret := lo.ToPtr(*e)
+	ret := new(*e)
 	return ret
 }
 

--- a/back/module/schoolcalendar/domain/module_detail.go
+++ b/back/module/schoolcalendar/domain/module_detail.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/civil"
-	"github.com/samber/lo"
 	"github.com/twin-te/twin-te/back/base"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
@@ -58,7 +57,7 @@ type ModuleDetail struct {
 }
 
 func (md *ModuleDetail) Clone() *ModuleDetail {
-	ret := lo.ToPtr(*md)
+	ret := new(*md)
 	return ret
 }
 

--- a/back/module/shared/domain/idtype/already_read_id_gen.go
+++ b/back/module/shared/domain/idtype/already_read_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type AlreadyReadID uuid.UUID
@@ -33,7 +32,7 @@ func (id *AlreadyReadID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewAlreadyReadID() AlreadyReadID {

--- a/back/module/shared/domain/idtype/announcement_id_gen.go
+++ b/back/module/shared/domain/idtype/announcement_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type AnnouncementID uuid.UUID
@@ -33,7 +32,7 @@ func (id *AnnouncementID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewAnnouncementID() AnnouncementID {

--- a/back/module/shared/domain/idtype/course_id_gen.go
+++ b/back/module/shared/domain/idtype/course_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type CourseID uuid.UUID
@@ -33,7 +32,7 @@ func (id *CourseID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewCourseID() CourseID {

--- a/back/module/shared/domain/idtype/registered_course_id_gen.go
+++ b/back/module/shared/domain/idtype/registered_course_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type RegisteredCourseID uuid.UUID
@@ -33,7 +32,7 @@ func (id *RegisteredCourseID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewRegisteredCourseID() RegisteredCourseID {

--- a/back/module/shared/domain/idtype/session_id_gen.go
+++ b/back/module/shared/domain/idtype/session_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type SessionID uuid.UUID
@@ -33,7 +32,7 @@ func (id *SessionID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewSessionID() SessionID {

--- a/back/module/shared/domain/idtype/tag_id_gen.go
+++ b/back/module/shared/domain/idtype/tag_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type TagID uuid.UUID
@@ -33,7 +32,7 @@ func (id *TagID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewTagID() TagID {

--- a/back/module/shared/domain/idtype/user_id_gen.go
+++ b/back/module/shared/domain/idtype/user_id_gen.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type UserID uuid.UUID
@@ -33,7 +32,7 @@ func (id *UserID) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func NewUserID() UserID {

--- a/back/module/shared/domain/required_string.go
+++ b/back/module/shared/domain/required_string.go
@@ -3,8 +3,6 @@ package shareddomain
 import (
 	"fmt"
 	"strings"
-
-	"github.com/samber/lo"
 )
 
 // RequiredString represents non-empty string.
@@ -19,7 +17,7 @@ func (rs *RequiredString) StringPtr() *string {
 	if rs == nil {
 		return nil
 	}
-	return lo.ToPtr(rs.String())
+	return new(rs.String())
 }
 
 func (rs RequiredString) IsZero() bool {

--- a/back/module/timetable/domain/course.go
+++ b/back/module/timetable/domain/course.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/twin-te/twin-te/back/base"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
@@ -34,7 +33,7 @@ type Course struct {
 }
 
 func (c *Course) Clone() *Course {
-	ret := lo.ToPtr(*c)
+	ret := new(*c)
 	ret.RecommendedGrades = base.CopySlice(c.RecommendedGrades)
 	ret.Methods = base.CopySlice(c.Methods)
 	ret.Schedules = base.CopySlice(c.Schedules)

--- a/back/module/timetable/domain/registered_course.go
+++ b/back/module/timetable/domain/registered_course.go
@@ -64,7 +64,7 @@ func (rc *RegisteredCourse) HasBasedCourse() bool {
 }
 
 func (rc *RegisteredCourse) Clone() *RegisteredCourse {
-	ret := lo.ToPtr(*rc)
+	ret := new(*rc)
 	ret.Methods = base.OptionCloneBy(rc.Methods, base.CopySlice)
 	ret.Schedules = base.OptionCloneBy(rc.Schedules, base.CopySlice)
 	ret.TagIDs = base.CopySlice(rc.TagIDs)

--- a/back/module/timetable/domain/tag.go
+++ b/back/module/timetable/domain/tag.go
@@ -3,7 +3,6 @@ package timetabledomain
 import (
 	"fmt"
 
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
@@ -24,7 +23,7 @@ type Tag struct {
 }
 
 func (t *Tag) Clone() *Tag {
-	ret := lo.ToPtr(*t)
+	ret := new(*t)
 	return ret
 }
 

--- a/codegen/idtype/uuid_template.txt
+++ b/codegen/idtype/uuid_template.txt
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/samber/lo"
 )
 
 type ${id_name} uuid.UUID
@@ -33,7 +32,7 @@ func (id *${id_name}) StringPtr() *string {
 	if id == nil {
 		return nil
 	}
-	return lo.ToPtr(id.String())
+	return new(id.String())
 }
 
 func New${id_name}() ${id_name} {

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ docker compose --profile docker up
 proxy-host, db, db-migrationのみをDockerコンテナで実行し、他のサービスはホストマシン上で実行する方法です。
 
 バージョン
-- Go : 1.23.x
+- Go : 1.26.x
 - Python : 3.12.x
 - [uv](https://docs.astral.sh/uv/): 0.8.x
 - Bun : 1.2.x


### PR DESCRIPTION
Goのバージョンを1.26に更新し、[go fix](https://go.dev/blog/gofix) を実行しました

一部Stripeの型が消えていたり怪しい箇所があったのでその部分だけ修正しました

手元で一通り動作確認済みです