### PR TITLE
[back] ベースイメージをtrixieにする

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   --mount=type=bind,target=. \
   GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -trimpath -o /usr/local/bin/app
 
-FROM debian:bullseye-slim AS deploy
+FROM debian:trixie-slim AS deploy
 
 RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -11,7 +11,7 @@ FROM base AS local
 
 CMD [ "go", "tool", "air" ]
 
-FROM golang:${GO_VERSION}-bullseye AS builder
+FROM golang:${GO_VERSION}-trixie AS builder
 WORKDIR /usr/src/app
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \


### PR DESCRIPTION
ref: https://github.com/twin-te/twin-te/actions/runs/24329124039/job/71030687956

```
docker build -t twinte-back --target deploy --no-cache ./back
[+] Building 16.4s (12/12) FINISHED                                                 docker:orbstack
 => [internal] load build definition from Dockerfile                                           0.0s
 => => transferring dockerfile: 881B                                                           0.0s
 => [internal] load metadata for docker.io/library/debian:trixie-slim                          0.9s
 => [internal] load metadata for docker.io/library/golang:1.26.2-trixie                        0.9s
 => [internal] load .dockerignore                                                              0.1s
 => => transferring context: 2B                                                                0.0s
 => [builder 1/3] FROM docker.io/library/golang:1.26.2-trixie@sha256:c0074c718b473f3827043f86  0.0s
 => => resolve docker.io/library/golang:1.26.2-trixie@sha256:c0074c718b473f3827043f86532c4c0f  0.0s
 => [internal] load build context                                                              0.0s
 => => transferring context: 19.55kB                                                           0.0s
 => CACHED [deploy 1/3] FROM docker.io/library/debian:trixie-slim@sha256:4ffb3a1511099754cddc  0.0s
 => CACHED [builder 2/3] WORKDIR /usr/src/app                                                  0.0s
 => [deploy 2/3] RUN --mount=type=cache,target=/var/lib/apt,sharing=locked   --mount=type=cac  4.3s
 => [builder 3/3] RUN --mount=type=cache,target=/go/pkg/mod/   --mount=type=bind,target=.     13.9s
 => [deploy 3/3] COPY --from=builder /usr/local/bin/app .                                      0.1s
 => exporting to image                                                                         0.1s
 => => exporting layers                                                                        0.1s
 => => writing image sha256:ac1d4c380f60eae2512849d7ee73995551fb8c6a7e62084facfe7576b2a5aec8   0.0s
 => => naming to docker.io/library/twinte-back                                                 0.0s
```