### PR TITLE
[back] ics に `NAME` と `X-WR-CALNAME` を追加

### DIFF
--- a/back/module/calendar/usecase/ics.go
+++ b/back/module/calendar/usecase/ics.go
@@ -56,6 +56,8 @@ func (uc *impl) writeICalendar(writer io.Writer, modules []calendardomain.School
 	w.write("BEGIN:VCALENDAR")
 	w.write("VERSION:2.0")
 	w.write("PRODID:-//Twin:te//Twin:te Calendar Service//EN")
+	w.write("NAME:Twin:te")
+	w.write("X-WR-CALNAME:Twin:te")
 
 	w.write("BEGIN:VTIMEZONE")
 	w.write("TZID:Asia/Tokyo")


### PR DESCRIPTION
Google Calendar 等へのカレンダー登録時に URL でなくカレンダー名が表示されるように
https://meta.discourse.org/t/the-webcal-url-is-incorrectly-passed-to-the-calendar-name-field-in-google-calendar/400167