### PR TITLE
[sponsorship] next.config.jsからimages.domanisを削除

### DIFF
--- a/sponsorship/next.config.js
+++ b/sponsorship/next.config.js
@@ -2,9 +2,6 @@
 const nextConfig = {
 	basePath: '/sponsorship',
 	reactStrictMode: true,
-	images: {
-		domains: ["www.datocms-assets.com"],
-	},
 	output: "standalone"
 };
 


### PR DESCRIPTION
https://github.com/twin-te/twinte-sponsorship/blob/0b65fce03a2b2e8ab5988bd4cc84d14a5e8d5c47/components/Layout.tsx#L67 でVercelのロゴを表示するために設定されていたと思われる。現在このロゴは参照されていないので、削除した。