### PR TITLE
feat(backend): カレンダー連携で特定タグの科目を除外/「予定なし」にする (#433)

### DIFF
--- a/back/handler/api/v4/rpc/calendar/v1/svc/impl.go
+++ b/back/handler/api/v4/rpc/calendar/v1/svc/impl.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/bufbuild/connect-go"
 	"github.com/twin-te/twin-te/back/appenv"
+	"github.com/twin-te/twin-te/back/base"
+	sharedconv "github.com/twin-te/twin-te/back/handler/api/v4/rpc/shared/conv"
 	calendarv1 "github.com/twin-te/twin-te/back/handler/api/v4/rpcgen/calendar/v1"
 	"github.com/twin-te/twin-te/back/handler/api/v4/rpcgen/calendar/v1/calendarv1connect"
 	calendarv1handler "github.com/twin-te/twin-te/back/handler/calendar/v1"
 	calendarmodule "github.com/twin-te/twin-te/back/module/calendar"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
+	sharederr "github.com/twin-te/twin-te/back/module/shared/err"
 )
 
 var _ calendarv1connect.CalendarServiceHandler = (*impl)(nil)
@@ -20,20 +24,20 @@ type impl struct {
 }
 
 func (svc *impl) GetIcalSubscriptionUrl(ctx context.Context, req *connect.Request[calendarv1.GetIcalSubscriptionUrlRequest]) (res *connect.Response[calendarv1.GetIcalSubscriptionUrlResponse], err error) {
-	optID, err := svc.uc.FindIcalSubscriptionID(ctx)
+	optSub, err := svc.uc.FindIcalSubscription(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var url *string
-	if id, ok := optID.Get(); ok {
-		urlVal := buildIcalSubscriptionUrl(id)
-		url = &urlVal
+	msg := &calendarv1.GetIcalSubscriptionUrlResponse{}
+	if sub, ok := optSub.Get(); ok {
+		urlVal := buildIcalSubscriptionUrl(sub.ID)
+		msg.Url = &urlVal
+		msg.Mode = toPBIcalSubscriptionMode(sub.Mode)
+		msg.TargetTagIds = base.Map(sub.TargetTagIDs, sharedconv.ToPBUUID[idtype.TagID])
 	}
 
-	res = connect.NewResponse(&calendarv1.GetIcalSubscriptionUrlResponse{
-		Url: url,
-	})
+	res = connect.NewResponse(msg)
 
 	return
 }
@@ -51,6 +55,50 @@ func (svc *impl) DisableIcalSubscription(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 	return connect.NewResponse(&calendarv1.DisableIcalSubscriptionResponse{}), nil
+}
+
+func (svc *impl) UpdateIcalSubscription(ctx context.Context, req *connect.Request[calendarv1.UpdateIcalSubscriptionRequest]) (*connect.Response[calendarv1.UpdateIcalSubscriptionResponse], error) {
+	mode, err := fromPBIcalSubscriptionMode(req.Msg.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	targetTagIDs, err := base.MapWithArgAndErr(req.Msg.TargetTagIds, idtype.ParseTagID, sharedconv.FromPBUUID[idtype.TagID])
+	if err != nil {
+		return nil, err
+	}
+
+	if err := svc.uc.UpdateIcalSubscription(ctx, mode, targetTagIDs); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&calendarv1.UpdateIcalSubscriptionResponse{}), nil
+}
+
+func fromPBIcalSubscriptionMode(mode calendarv1.IcalSubscriptionMode) (calendardomain.IcalSubscriptionMode, error) {
+	switch mode {
+	case calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_SYNC:
+		return calendardomain.IcalSubscriptionModeSync, nil
+	case calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_EXCLUDE:
+		return calendardomain.IcalSubscriptionModeExclude, nil
+	case calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_TRANSPARENT:
+		return calendardomain.IcalSubscriptionModeTransparent, nil
+	default:
+		return "", sharederr.NewInvalidArgument("invalid ical subscription mode")
+	}
+}
+
+func toPBIcalSubscriptionMode(mode calendardomain.IcalSubscriptionMode) calendarv1.IcalSubscriptionMode {
+	switch mode {
+	case calendardomain.IcalSubscriptionModeSync:
+		return calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_SYNC
+	case calendardomain.IcalSubscriptionModeExclude:
+		return calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_EXCLUDE
+	case calendardomain.IcalSubscriptionModeTransparent:
+		return calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_TRANSPARENT
+	default:
+		return calendarv1.IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_UNSPECIFIED
+	}
 }
 
 func buildIcalSubscriptionUrl(id idtype.IcalSubscriptionID) string {

--- a/back/handler/api/v4/rpcgen/calendar/v1/calendarv1connect/service.connect.go
+++ b/back/handler/api/v4/rpcgen/calendar/v1/calendarv1connect/service.connect.go
@@ -42,6 +42,9 @@ const (
 	// CalendarServiceDisableIcalSubscriptionProcedure is the fully-qualified name of the
 	// CalendarService's DisableIcalSubscription RPC.
 	CalendarServiceDisableIcalSubscriptionProcedure = "/calendar.v1.CalendarService/DisableIcalSubscription"
+	// CalendarServiceUpdateIcalSubscriptionProcedure is the fully-qualified name of the
+	// CalendarService's UpdateIcalSubscription RPC.
+	CalendarServiceUpdateIcalSubscriptionProcedure = "/calendar.v1.CalendarService/UpdateIcalSubscription"
 )
 
 // CalendarServiceClient is a client for the calendar.v1.CalendarService service.
@@ -49,6 +52,7 @@ type CalendarServiceClient interface {
 	GetIcalSubscriptionUrl(context.Context, *connect_go.Request[v1.GetIcalSubscriptionUrlRequest]) (*connect_go.Response[v1.GetIcalSubscriptionUrlResponse], error)
 	EnableIcalSubscription(context.Context, *connect_go.Request[v1.EnableIcalSubscriptionRequest]) (*connect_go.Response[v1.EnableIcalSubscriptionResponse], error)
 	DisableIcalSubscription(context.Context, *connect_go.Request[v1.DisableIcalSubscriptionRequest]) (*connect_go.Response[v1.DisableIcalSubscriptionResponse], error)
+	UpdateIcalSubscription(context.Context, *connect_go.Request[v1.UpdateIcalSubscriptionRequest]) (*connect_go.Response[v1.UpdateIcalSubscriptionResponse], error)
 }
 
 // NewCalendarServiceClient constructs a client for the calendar.v1.CalendarService service. By
@@ -77,6 +81,11 @@ func NewCalendarServiceClient(httpClient connect_go.HTTPClient, baseURL string, 
 			baseURL+CalendarServiceDisableIcalSubscriptionProcedure,
 			opts...,
 		),
+		updateIcalSubscription: connect_go.NewClient[v1.UpdateIcalSubscriptionRequest, v1.UpdateIcalSubscriptionResponse](
+			httpClient,
+			baseURL+CalendarServiceUpdateIcalSubscriptionProcedure,
+			opts...,
+		),
 	}
 }
 
@@ -85,6 +94,7 @@ type calendarServiceClient struct {
 	getIcalSubscriptionUrl  *connect_go.Client[v1.GetIcalSubscriptionUrlRequest, v1.GetIcalSubscriptionUrlResponse]
 	enableIcalSubscription  *connect_go.Client[v1.EnableIcalSubscriptionRequest, v1.EnableIcalSubscriptionResponse]
 	disableIcalSubscription *connect_go.Client[v1.DisableIcalSubscriptionRequest, v1.DisableIcalSubscriptionResponse]
+	updateIcalSubscription  *connect_go.Client[v1.UpdateIcalSubscriptionRequest, v1.UpdateIcalSubscriptionResponse]
 }
 
 // GetIcalSubscriptionUrl calls calendar.v1.CalendarService.GetIcalSubscriptionUrl.
@@ -102,11 +112,17 @@ func (c *calendarServiceClient) DisableIcalSubscription(ctx context.Context, req
 	return c.disableIcalSubscription.CallUnary(ctx, req)
 }
 
+// UpdateIcalSubscription calls calendar.v1.CalendarService.UpdateIcalSubscription.
+func (c *calendarServiceClient) UpdateIcalSubscription(ctx context.Context, req *connect_go.Request[v1.UpdateIcalSubscriptionRequest]) (*connect_go.Response[v1.UpdateIcalSubscriptionResponse], error) {
+	return c.updateIcalSubscription.CallUnary(ctx, req)
+}
+
 // CalendarServiceHandler is an implementation of the calendar.v1.CalendarService service.
 type CalendarServiceHandler interface {
 	GetIcalSubscriptionUrl(context.Context, *connect_go.Request[v1.GetIcalSubscriptionUrlRequest]) (*connect_go.Response[v1.GetIcalSubscriptionUrlResponse], error)
 	EnableIcalSubscription(context.Context, *connect_go.Request[v1.EnableIcalSubscriptionRequest]) (*connect_go.Response[v1.EnableIcalSubscriptionResponse], error)
 	DisableIcalSubscription(context.Context, *connect_go.Request[v1.DisableIcalSubscriptionRequest]) (*connect_go.Response[v1.DisableIcalSubscriptionResponse], error)
+	UpdateIcalSubscription(context.Context, *connect_go.Request[v1.UpdateIcalSubscriptionRequest]) (*connect_go.Response[v1.UpdateIcalSubscriptionResponse], error)
 }
 
 // NewCalendarServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -131,6 +147,11 @@ func NewCalendarServiceHandler(svc CalendarServiceHandler, opts ...connect_go.Ha
 		svc.DisableIcalSubscription,
 		opts...,
 	)
+	calendarServiceUpdateIcalSubscriptionHandler := connect_go.NewUnaryHandler(
+		CalendarServiceUpdateIcalSubscriptionProcedure,
+		svc.UpdateIcalSubscription,
+		opts...,
+	)
 	return "/calendar.v1.CalendarService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case CalendarServiceGetIcalSubscriptionUrlProcedure:
@@ -139,6 +160,8 @@ func NewCalendarServiceHandler(svc CalendarServiceHandler, opts ...connect_go.Ha
 			calendarServiceEnableIcalSubscriptionHandler.ServeHTTP(w, r)
 		case CalendarServiceDisableIcalSubscriptionProcedure:
 			calendarServiceDisableIcalSubscriptionHandler.ServeHTTP(w, r)
+		case CalendarServiceUpdateIcalSubscriptionProcedure:
+			calendarServiceUpdateIcalSubscriptionHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -158,4 +181,8 @@ func (UnimplementedCalendarServiceHandler) EnableIcalSubscription(context.Contex
 
 func (UnimplementedCalendarServiceHandler) DisableIcalSubscription(context.Context, *connect_go.Request[v1.DisableIcalSubscriptionRequest]) (*connect_go.Response[v1.DisableIcalSubscriptionResponse], error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("calendar.v1.CalendarService.DisableIcalSubscription is not implemented"))
+}
+
+func (UnimplementedCalendarServiceHandler) UpdateIcalSubscription(context.Context, *connect_go.Request[v1.UpdateIcalSubscriptionRequest]) (*connect_go.Response[v1.UpdateIcalSubscriptionResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("calendar.v1.CalendarService.UpdateIcalSubscription is not implemented"))
 }

--- a/back/handler/api/v4/rpcgen/calendar/v1/service.pb.go
+++ b/back/handler/api/v4/rpcgen/calendar/v1/service.pb.go
@@ -7,7 +7,7 @@
 package calendarv1
 
 import (
-	_ "github.com/twin-te/twin-te/back/handler/api/v4/rpcgen/sharedpb"
+	sharedpb "github.com/twin-te/twin-te/back/handler/api/v4/rpcgen/sharedpb"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -21,6 +21,62 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// IcalSubscriptionMode は target_tag_ids が付与されたコースを iCal フィードでどう出力するかを制御する。
+type IcalSubscriptionMode int32
+
+const (
+	IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_UNSPECIFIED IcalSubscriptionMode = 0
+	// SYNC はすべてのコースを通常出力する。target_tag_ids は空でなければならない。
+	IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_SYNC IcalSubscriptionMode = 1
+	// EXCLUDE は target_tag_ids のいずれかのタグを持つコースを出力しない。
+	IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_EXCLUDE IcalSubscriptionMode = 2
+	// TRANSPARENT は target_tag_ids のいずれかのタグを持つコースに TRANSP:TRANSPARENT を付与する。
+	IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_TRANSPARENT IcalSubscriptionMode = 3
+)
+
+// Enum value maps for IcalSubscriptionMode.
+var (
+	IcalSubscriptionMode_name = map[int32]string{
+		0: "ICAL_SUBSCRIPTION_MODE_UNSPECIFIED",
+		1: "ICAL_SUBSCRIPTION_MODE_SYNC",
+		2: "ICAL_SUBSCRIPTION_MODE_EXCLUDE",
+		3: "ICAL_SUBSCRIPTION_MODE_TRANSPARENT",
+	}
+	IcalSubscriptionMode_value = map[string]int32{
+		"ICAL_SUBSCRIPTION_MODE_UNSPECIFIED": 0,
+		"ICAL_SUBSCRIPTION_MODE_SYNC":        1,
+		"ICAL_SUBSCRIPTION_MODE_EXCLUDE":     2,
+		"ICAL_SUBSCRIPTION_MODE_TRANSPARENT": 3,
+	}
+)
+
+func (x IcalSubscriptionMode) Enum() *IcalSubscriptionMode {
+	p := new(IcalSubscriptionMode)
+	*p = x
+	return p
+}
+
+func (x IcalSubscriptionMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (IcalSubscriptionMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_calendar_v1_service_proto_enumTypes[0].Descriptor()
+}
+
+func (IcalSubscriptionMode) Type() protoreflect.EnumType {
+	return &file_calendar_v1_service_proto_enumTypes[0]
+}
+
+func (x IcalSubscriptionMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use IcalSubscriptionMode.Descriptor instead.
+func (IcalSubscriptionMode) EnumDescriptor() ([]byte, []int) {
+	return file_calendar_v1_service_proto_rawDescGZIP(), []int{0}
+}
 
 type GetIcalSubscriptionUrlRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -59,8 +115,11 @@ func (*GetIcalSubscriptionUrlRequest) Descriptor() ([]byte, []int) {
 }
 
 type GetIcalSubscriptionUrlResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Url           *string                `protobuf:"bytes,1,opt,name=url,proto3,oneof" json:"url,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Url   *string                `protobuf:"bytes,1,opt,name=url,proto3,oneof" json:"url,omitempty"`
+	// mode と target_tag_ids は現在の設定を表す。url が設定されているときのみ意味を持つ。
+	Mode          IcalSubscriptionMode `protobuf:"varint,2,opt,name=mode,proto3,enum=calendar.v1.IcalSubscriptionMode" json:"mode,omitempty"`
+	TargetTagIds  []*sharedpb.UUID     `protobuf:"bytes,3,rep,name=target_tag_ids,json=targetTagIds,proto3" json:"target_tag_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -100,6 +159,20 @@ func (x *GetIcalSubscriptionUrlResponse) GetUrl() string {
 		return *x.Url
 	}
 	return ""
+}
+
+func (x *GetIcalSubscriptionUrlResponse) GetMode() IcalSubscriptionMode {
+	if x != nil {
+		return x.Mode
+	}
+	return IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_UNSPECIFIED
+}
+
+func (x *GetIcalSubscriptionUrlResponse) GetTargetTagIds() []*sharedpb.UUID {
+	if x != nil {
+		return x.TargetTagIds
+	}
+	return nil
 }
 
 type EnableIcalSubscriptionRequest struct {
@@ -254,24 +327,124 @@ func (*DisableIcalSubscriptionResponse) Descriptor() ([]byte, []int) {
 	return file_calendar_v1_service_proto_rawDescGZIP(), []int{5}
 }
 
+type UpdateIcalSubscriptionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Mode          IcalSubscriptionMode   `protobuf:"varint,1,opt,name=mode,proto3,enum=calendar.v1.IcalSubscriptionMode" json:"mode,omitempty"`
+	TargetTagIds  []*sharedpb.UUID       `protobuf:"bytes,2,rep,name=target_tag_ids,json=targetTagIds,proto3" json:"target_tag_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateIcalSubscriptionRequest) Reset() {
+	*x = UpdateIcalSubscriptionRequest{}
+	mi := &file_calendar_v1_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateIcalSubscriptionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateIcalSubscriptionRequest) ProtoMessage() {}
+
+func (x *UpdateIcalSubscriptionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_calendar_v1_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateIcalSubscriptionRequest.ProtoReflect.Descriptor instead.
+func (*UpdateIcalSubscriptionRequest) Descriptor() ([]byte, []int) {
+	return file_calendar_v1_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *UpdateIcalSubscriptionRequest) GetMode() IcalSubscriptionMode {
+	if x != nil {
+		return x.Mode
+	}
+	return IcalSubscriptionMode_ICAL_SUBSCRIPTION_MODE_UNSPECIFIED
+}
+
+func (x *UpdateIcalSubscriptionRequest) GetTargetTagIds() []*sharedpb.UUID {
+	if x != nil {
+		return x.TargetTagIds
+	}
+	return nil
+}
+
+type UpdateIcalSubscriptionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateIcalSubscriptionResponse) Reset() {
+	*x = UpdateIcalSubscriptionResponse{}
+	mi := &file_calendar_v1_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateIcalSubscriptionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateIcalSubscriptionResponse) ProtoMessage() {}
+
+func (x *UpdateIcalSubscriptionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_calendar_v1_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateIcalSubscriptionResponse.ProtoReflect.Descriptor instead.
+func (*UpdateIcalSubscriptionResponse) Descriptor() ([]byte, []int) {
+	return file_calendar_v1_service_proto_rawDescGZIP(), []int{7}
+}
+
 var File_calendar_v1_service_proto protoreflect.FileDescriptor
 
 const file_calendar_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x19calendar/v1/service.proto\x12\vcalendar.v1\x1a\x13shared/option.proto\"\x1f\n" +
-	"\x1dGetIcalSubscriptionUrlRequest\"?\n" +
+	"\x19calendar/v1/service.proto\x12\vcalendar.v1\x1a\x13shared/option.proto\x1a\x11shared/type.proto\"\x1f\n" +
+	"\x1dGetIcalSubscriptionUrlRequest\"\xaa\x01\n" +
 	"\x1eGetIcalSubscriptionUrlResponse\x12\x15\n" +
-	"\x03url\x18\x01 \x01(\tH\x00R\x03url\x88\x01\x01B\x06\n" +
+	"\x03url\x18\x01 \x01(\tH\x00R\x03url\x88\x01\x01\x125\n" +
+	"\x04mode\x18\x02 \x01(\x0e2!.calendar.v1.IcalSubscriptionModeR\x04mode\x122\n" +
+	"\x0etarget_tag_ids\x18\x03 \x03(\v2\f.shared.UUIDR\ftargetTagIdsB\x06\n" +
 	"\x04_url\"\x1f\n" +
 	"\x1dEnableIcalSubscriptionRequest\"2\n" +
 	"\x1eEnableIcalSubscriptionResponse\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\" \n" +
 	"\x1eDisableIcalSubscriptionRequest\"!\n" +
-	"\x1fDisableIcalSubscriptionResponse2\x88\x03\n" +
+	"\x1fDisableIcalSubscriptionResponse\"\x8a\x01\n" +
+	"\x1dUpdateIcalSubscriptionRequest\x125\n" +
+	"\x04mode\x18\x01 \x01(\x0e2!.calendar.v1.IcalSubscriptionModeR\x04mode\x122\n" +
+	"\x0etarget_tag_ids\x18\x02 \x03(\v2\f.shared.UUIDR\ftargetTagIds\" \n" +
+	"\x1eUpdateIcalSubscriptionResponse*\xab\x01\n" +
+	"\x14IcalSubscriptionMode\x12&\n" +
+	"\"ICAL_SUBSCRIPTION_MODE_UNSPECIFIED\x10\x00\x12\x1f\n" +
+	"\x1bICAL_SUBSCRIPTION_MODE_SYNC\x10\x01\x12\"\n" +
+	"\x1eICAL_SUBSCRIPTION_MODE_EXCLUDE\x10\x02\x12&\n" +
+	"\"ICAL_SUBSCRIPTION_MODE_TRANSPARENT\x10\x032\x83\x04\n" +
 	"\x0fCalendarService\x12|\n" +
 	"\x16GetIcalSubscriptionUrl\x12*.calendar.v1.GetIcalSubscriptionUrlRequest\x1a+.calendar.v1.GetIcalSubscriptionUrlResponse\"\t\x82\xb5\x18\x02\b\x03\x90\x02\x01\x12y\n" +
 	"\x16EnableIcalSubscription\x12*.calendar.v1.EnableIcalSubscriptionRequest\x1a+.calendar.v1.EnableIcalSubscriptionResponse\"\x06\x82\xb5\x18\x02\b\x03\x12|\n" +
-	"\x17DisableIcalSubscription\x12+.calendar.v1.DisableIcalSubscriptionRequest\x1a,.calendar.v1.DisableIcalSubscriptionResponse\"\x06\x82\xb5\x18\x02\b\x03Bj\n" +
+	"\x17DisableIcalSubscription\x12+.calendar.v1.DisableIcalSubscriptionRequest\x1a,.calendar.v1.DisableIcalSubscriptionResponse\"\x06\x82\xb5\x18\x02\b\x03\x12y\n" +
+	"\x16UpdateIcalSubscription\x12*.calendar.v1.UpdateIcalSubscriptionRequest\x1a+.calendar.v1.UpdateIcalSubscriptionResponse\"\x06\x82\xb5\x18\x02\b\x03Bj\n" +
 	"\x1anet.twinte.api.calendar.v1ZLgithub.com/twin-te/twin-te/back/handler/api/v4/rpcgen/calendar/v1;calendarv1b\x06proto3"
 
 var (
@@ -286,27 +459,38 @@ func file_calendar_v1_service_proto_rawDescGZIP() []byte {
 	return file_calendar_v1_service_proto_rawDescData
 }
 
-var file_calendar_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_calendar_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_calendar_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_calendar_v1_service_proto_goTypes = []any{
-	(*GetIcalSubscriptionUrlRequest)(nil),   // 0: calendar.v1.GetIcalSubscriptionUrlRequest
-	(*GetIcalSubscriptionUrlResponse)(nil),  // 1: calendar.v1.GetIcalSubscriptionUrlResponse
-	(*EnableIcalSubscriptionRequest)(nil),   // 2: calendar.v1.EnableIcalSubscriptionRequest
-	(*EnableIcalSubscriptionResponse)(nil),  // 3: calendar.v1.EnableIcalSubscriptionResponse
-	(*DisableIcalSubscriptionRequest)(nil),  // 4: calendar.v1.DisableIcalSubscriptionRequest
-	(*DisableIcalSubscriptionResponse)(nil), // 5: calendar.v1.DisableIcalSubscriptionResponse
+	(IcalSubscriptionMode)(0),               // 0: calendar.v1.IcalSubscriptionMode
+	(*GetIcalSubscriptionUrlRequest)(nil),   // 1: calendar.v1.GetIcalSubscriptionUrlRequest
+	(*GetIcalSubscriptionUrlResponse)(nil),  // 2: calendar.v1.GetIcalSubscriptionUrlResponse
+	(*EnableIcalSubscriptionRequest)(nil),   // 3: calendar.v1.EnableIcalSubscriptionRequest
+	(*EnableIcalSubscriptionResponse)(nil),  // 4: calendar.v1.EnableIcalSubscriptionResponse
+	(*DisableIcalSubscriptionRequest)(nil),  // 5: calendar.v1.DisableIcalSubscriptionRequest
+	(*DisableIcalSubscriptionResponse)(nil), // 6: calendar.v1.DisableIcalSubscriptionResponse
+	(*UpdateIcalSubscriptionRequest)(nil),   // 7: calendar.v1.UpdateIcalSubscriptionRequest
+	(*UpdateIcalSubscriptionResponse)(nil),  // 8: calendar.v1.UpdateIcalSubscriptionResponse
+	(*sharedpb.UUID)(nil),                   // 9: shared.UUID
 }
 var file_calendar_v1_service_proto_depIdxs = []int32{
-	0, // 0: calendar.v1.CalendarService.GetIcalSubscriptionUrl:input_type -> calendar.v1.GetIcalSubscriptionUrlRequest
-	2, // 1: calendar.v1.CalendarService.EnableIcalSubscription:input_type -> calendar.v1.EnableIcalSubscriptionRequest
-	4, // 2: calendar.v1.CalendarService.DisableIcalSubscription:input_type -> calendar.v1.DisableIcalSubscriptionRequest
-	1, // 3: calendar.v1.CalendarService.GetIcalSubscriptionUrl:output_type -> calendar.v1.GetIcalSubscriptionUrlResponse
-	3, // 4: calendar.v1.CalendarService.EnableIcalSubscription:output_type -> calendar.v1.EnableIcalSubscriptionResponse
-	5, // 5: calendar.v1.CalendarService.DisableIcalSubscription:output_type -> calendar.v1.DisableIcalSubscriptionResponse
-	3, // [3:6] is the sub-list for method output_type
-	0, // [0:3] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: calendar.v1.GetIcalSubscriptionUrlResponse.mode:type_name -> calendar.v1.IcalSubscriptionMode
+	9, // 1: calendar.v1.GetIcalSubscriptionUrlResponse.target_tag_ids:type_name -> shared.UUID
+	0, // 2: calendar.v1.UpdateIcalSubscriptionRequest.mode:type_name -> calendar.v1.IcalSubscriptionMode
+	9, // 3: calendar.v1.UpdateIcalSubscriptionRequest.target_tag_ids:type_name -> shared.UUID
+	1, // 4: calendar.v1.CalendarService.GetIcalSubscriptionUrl:input_type -> calendar.v1.GetIcalSubscriptionUrlRequest
+	3, // 5: calendar.v1.CalendarService.EnableIcalSubscription:input_type -> calendar.v1.EnableIcalSubscriptionRequest
+	5, // 6: calendar.v1.CalendarService.DisableIcalSubscription:input_type -> calendar.v1.DisableIcalSubscriptionRequest
+	7, // 7: calendar.v1.CalendarService.UpdateIcalSubscription:input_type -> calendar.v1.UpdateIcalSubscriptionRequest
+	2, // 8: calendar.v1.CalendarService.GetIcalSubscriptionUrl:output_type -> calendar.v1.GetIcalSubscriptionUrlResponse
+	4, // 9: calendar.v1.CalendarService.EnableIcalSubscription:output_type -> calendar.v1.EnableIcalSubscriptionResponse
+	6, // 10: calendar.v1.CalendarService.DisableIcalSubscription:output_type -> calendar.v1.DisableIcalSubscriptionResponse
+	8, // 11: calendar.v1.CalendarService.UpdateIcalSubscription:output_type -> calendar.v1.UpdateIcalSubscriptionResponse
+	8, // [8:12] is the sub-list for method output_type
+	4, // [4:8] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_calendar_v1_service_proto_init() }
@@ -320,13 +504,14 @@ func file_calendar_v1_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_calendar_v1_service_proto_rawDesc), len(file_calendar_v1_service_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   6,
+			NumEnums:      1,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_calendar_v1_service_proto_goTypes,
 		DependencyIndexes: file_calendar_v1_service_proto_depIdxs,
+		EnumInfos:         file_calendar_v1_service_proto_enumTypes,
 		MessageInfos:      file_calendar_v1_service_proto_msgTypes,
 	}.Build()
 	File_calendar_v1_service_proto = out.File

--- a/back/module/calendar/adapter/repository/ical_subscription.go
+++ b/back/module/calendar/adapter/repository/ical_subscription.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/samber/mo"
+	"github.com/twin-te/twin-te/back/base"
 	dbhelper "github.com/twin-te/twin-te/back/db/helper"
 	calendardbmodel "github.com/twin-te/twin-te/back/module/calendar/dbmodel"
 	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
@@ -13,27 +14,31 @@ import (
 )
 
 func (r *impl) FindIcalSubscriptionByID(ctx context.Context, id idtype.IcalSubscriptionID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error) {
-	db := r.db.WithContext(ctx).Preload("TargetTags").Where("id = ?", id.String())
-	db = dbhelper.ApplyLock(db, lock)
-	return takeIcalSubscription(db)
+	dbSub := new(calendardbmodel.IcalSubscription)
+	
+	err := r.transaction(ctx, func(tx *gorm.DB) error {
+		tx = dbhelper.ApplyLock(tx.Preload("TargetTags").Where("id = ?", id.String()), lock)
+		return tx.Take(dbSub).Error
+	}, true)
+	if err != nil {
+		return dbhelper.ConvertErrRecordNotFound[*calendardomain.IcalSubscription](err)
+	}
+
+	return base.SomeWithErr(calendardbmodel.FromDBIcalSubscription(dbSub))
 }
 
 func (r *impl) FindIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error) {
-	db := r.db.WithContext(ctx).Preload("TargetTags").Where("user_id = ?", userID.String())
-	db = dbhelper.ApplyLock(db, lock)
-	return takeIcalSubscription(db)
-}
-
-func takeIcalSubscription(db *gorm.DB) (mo.Option[*calendardomain.IcalSubscription], error) {
 	dbSub := new(calendardbmodel.IcalSubscription)
-	if err := db.Take(dbSub).Error; err != nil {
+
+	err := r.transaction(ctx, func(tx *gorm.DB) error {
+		tx = dbhelper.ApplyLock(tx.Preload("TargetTags").Where("user_id = ?", userID.String()), lock)
+		return tx.Take(dbSub).Error
+	}, true)
+	if err != nil {
 		return dbhelper.ConvertErrRecordNotFound[*calendardomain.IcalSubscription](err)
 	}
-	sub, err := calendardbmodel.FromDBIcalSubscription(dbSub)
-	if err != nil {
-		return mo.None[*calendardomain.IcalSubscription](), err
-	}
-	return mo.Some(sub), nil
+
+	return base.SomeWithErr(calendardbmodel.FromDBIcalSubscription(dbSub))
 }
 
 func (r *impl) CreateIcalSubscription(ctx context.Context, s *calendardomain.IcalSubscription) error {

--- a/back/module/calendar/adapter/repository/ical_subscription.go
+++ b/back/module/calendar/adapter/repository/ical_subscription.go
@@ -6,45 +6,64 @@ import (
 	"github.com/samber/mo"
 	dbhelper "github.com/twin-te/twin-te/back/db/helper"
 	calendardbmodel "github.com/twin-te/twin-te/back/module/calendar/dbmodel"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 	sharedport "github.com/twin-te/twin-te/back/module/shared/port"
 	"gorm.io/gorm"
 )
 
-func (r *impl) FindUserByIcalSubscriptionID(ctx context.Context, id idtype.IcalSubscriptionID, lock sharedport.Lock) (mo.Option[idtype.UserID], error) {
-	db := r.db.WithContext(ctx).Where("id = ?", id.String())
+func (r *impl) FindIcalSubscriptionByID(ctx context.Context, id idtype.IcalSubscriptionID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error) {
+	db := r.db.WithContext(ctx).Preload("TargetTags").Where("id = ?", id.String())
 	db = dbhelper.ApplyLock(db, lock)
-
-	dbSub := new(calendardbmodel.IcalSubscription)
-	if err := db.Take(dbSub).Error; err != nil {
-		return dbhelper.ConvertErrRecordNotFound[idtype.UserID](err)
-	}
-	userID, err := idtype.ParseUserID(dbSub.UserID)
-	if err != nil {
-		return mo.None[idtype.UserID](), err
-	}
-	return mo.Some(userID), nil
+	return takeIcalSubscription(db)
 }
 
-func (r *impl) FindIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID, lock sharedport.Lock) (mo.Option[idtype.IcalSubscriptionID], error) {
-	db := r.db.WithContext(ctx).Where("user_id = ?", userID.String())
+func (r *impl) FindIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error) {
+	db := r.db.WithContext(ctx).Preload("TargetTags").Where("user_id = ?", userID.String())
 	db = dbhelper.ApplyLock(db, lock)
-
-	dbSub := new(calendardbmodel.IcalSubscription)
-	if err := db.Take(dbSub).Error; err != nil {
-		return dbhelper.ConvertErrRecordNotFound[idtype.IcalSubscriptionID](err)
-	}
-	subID, err := idtype.ParseIcalSubscriptionID(dbSub.ID)
-	if err != nil {
-		return mo.None[idtype.IcalSubscriptionID](), err
-	}
-	return mo.Some(subID), nil
+	return takeIcalSubscription(db)
 }
 
-func (r *impl) CreateIcalSubscription(ctx context.Context, id idtype.IcalSubscriptionID, userID idtype.UserID) error {
-	dbSub := calendardbmodel.ToDBIcalSubscription(id, userID)
+func takeIcalSubscription(db *gorm.DB) (mo.Option[*calendardomain.IcalSubscription], error) {
+	dbSub := new(calendardbmodel.IcalSubscription)
+	if err := db.Take(dbSub).Error; err != nil {
+		return dbhelper.ConvertErrRecordNotFound[*calendardomain.IcalSubscription](err)
+	}
+	sub, err := calendardbmodel.FromDBIcalSubscription(dbSub)
+	if err != nil {
+		return mo.None[*calendardomain.IcalSubscription](), err
+	}
+	return mo.Some(sub), nil
+}
+
+func (r *impl) CreateIcalSubscription(ctx context.Context, s *calendardomain.IcalSubscription) error {
+	dbSub := calendardbmodel.ToDBIcalSubscription(s)
 	return r.transaction(ctx, func(tx *gorm.DB) error {
 		return tx.Create(dbSub).Error
+	}, false)
+}
+
+func (r *impl) UpdateIcalSubscription(ctx context.Context, s *calendardomain.IcalSubscription) error {
+	dbSub := calendardbmodel.ToDBIcalSubscription(s)
+	return r.transaction(ctx, func(tx *gorm.DB) error {
+		if err := tx.Model(&calendardbmodel.IcalSubscription{}).
+			Where("id = ?", dbSub.ID).
+			Update("mode", dbSub.Mode).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Where("ical_subscription_id = ?", dbSub.ID).
+			Delete(&calendardbmodel.IcalSubscriptionTargetTag{}).Error; err != nil {
+			return err
+		}
+
+		if len(dbSub.TargetTags) != 0 {
+			if err := tx.Create(&dbSub.TargetTags).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}, false)
 }
 

--- a/back/module/calendar/dbmodel/ical_subscription.go
+++ b/back/module/calendar/dbmodel/ical_subscription.go
@@ -3,20 +3,65 @@ package calendardbmodel
 import (
 	"time"
 
+	"github.com/twin-te/twin-te/back/base"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 )
 
 type IcalSubscription struct {
-	ID        string
-	UserID    string
-	
+	ID     string
+	UserID string
+	Mode   string
+
+	TargetTags []IcalSubscriptionTargetTag
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
-func ToDBIcalSubscription(id idtype.IcalSubscriptionID, userID idtype.UserID) *IcalSubscription {
+type IcalSubscriptionTargetTag struct {
+	IcalSubscriptionID string
+	TagID              string
+}
+
+func ToDBIcalSubscription(s *calendardomain.IcalSubscription) *IcalSubscription {
 	return &IcalSubscription{
-		ID:     id.String(),
-		UserID: userID.String(),
+		ID:     s.ID.String(),
+		UserID: s.UserID.String(),
+		Mode:   s.Mode.String(),
+		TargetTags: base.Map(s.TargetTagIDs, func(tagID idtype.TagID) IcalSubscriptionTargetTag {
+			return IcalSubscriptionTargetTag{
+				IcalSubscriptionID: s.ID.String(),
+				TagID:              tagID.String(),
+			}
+		}),
 	}
+}
+
+func FromDBIcalSubscription(dbSub *IcalSubscription) (*calendardomain.IcalSubscription, error) {
+	return calendardomain.ConstructIcalSubscription(func(s *calendardomain.IcalSubscription) (err error) {
+		s.ID, err = idtype.ParseIcalSubscriptionID(dbSub.ID)
+		if err != nil {
+			return err
+		}
+
+		s.UserID, err = idtype.ParseUserID(dbSub.UserID)
+		if err != nil {
+			return err
+		}
+
+		s.Mode, err = calendardomain.ParseIcalSubscriptionMode(dbSub.Mode)
+		if err != nil {
+			return err
+		}
+
+		s.TargetTagIDs, err = base.MapWithErr(dbSub.TargetTags, func(t IcalSubscriptionTargetTag) (idtype.TagID, error) {
+			return idtype.ParseTagID(t.TagID)
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 }

--- a/back/module/calendar/domain/ical_subscription.go
+++ b/back/module/calendar/domain/ical_subscription.go
@@ -1,0 +1,104 @@
+package calendardomain
+
+import (
+	"fmt"
+
+	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
+	sharederr "github.com/twin-te/twin-te/back/module/shared/err"
+	sharedhelper "github.com/twin-te/twin-te/back/module/shared/helper"
+)
+
+// IcalSubscriptionMode は TargetTagIDs が付与されたコースを iCal フィードでどう出力するかを制御する。
+type IcalSubscriptionMode string
+
+const (
+	// IcalSubscriptionModeSync はすべてのコースを通常出力する。TargetTagIDs は空でなければならない。
+	IcalSubscriptionModeSync IcalSubscriptionMode = "sync"
+	// IcalSubscriptionModeExclude は TargetTagIDs のいずれかのタグを持つコースを出力しない。
+	IcalSubscriptionModeExclude IcalSubscriptionMode = "exclude"
+	// IcalSubscriptionModeTransparent は TargetTagIDs のいずれかのタグを持つコースに TRANSP:TRANSPARENT を付与する。
+	IcalSubscriptionModeTransparent IcalSubscriptionMode = "transparent"
+)
+
+func ParseIcalSubscriptionMode(s string) (IcalSubscriptionMode, error) {
+	switch IcalSubscriptionMode(s) {
+	case IcalSubscriptionModeSync, IcalSubscriptionModeExclude, IcalSubscriptionModeTransparent:
+		return IcalSubscriptionMode(s), nil
+	default:
+		return "", sharederr.NewInvalidArgument("invalid ical subscription mode %q", s)
+	}
+}
+
+func (m IcalSubscriptionMode) String() string {
+	return string(m)
+}
+
+// IcalSubscription はユーザーごとの iCal フィード設定。
+type IcalSubscription struct {
+	ID           idtype.IcalSubscriptionID
+	UserID       idtype.UserID
+	Mode         IcalSubscriptionMode
+	TargetTagIDs []idtype.TagID
+}
+
+func ConstructIcalSubscription(fn func(s *IcalSubscription) (err error)) (*IcalSubscription, error) {
+	s := new(IcalSubscription)
+	if err := fn(s); err != nil {
+		return nil, err
+	}
+
+	if s.ID.IsZero() || s.UserID.IsZero() {
+		return nil, fmt.Errorf("failed to construct %+v", s)
+	}
+
+	if _, err := ParseIcalSubscriptionMode(s.Mode.String()); err != nil {
+		return nil, err
+	}
+
+	if err := s.validateTargetTagIDs(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// validateTargetTagIDs は TargetTagIDs の不変条件を検証する:
+//   - 重複が無いこと
+//   - Mode が sync のときは空であること
+//
+// タグの所有者（UserID に属すること）の検証はユースケース層で行う。
+func (s *IcalSubscription) validateTargetTagIDs() error {
+	if err := sharedhelper.ValidateDuplicates(s.TargetTagIDs); err != nil {
+		return err
+	}
+	if s.Mode == IcalSubscriptionModeSync && len(s.TargetTagIDs) != 0 {
+		return sharederr.NewInvalidArgument("target tag ids must be empty when mode is sync")
+	}
+	return nil
+}
+
+// IsTransparent は指定したタグ ID を持つコースを TRANSP:TRANSPARENT にすべきかを返す。
+func (s *IcalSubscription) IsTransparent(courseTagIDs []idtype.TagID) bool {
+	return s.Mode == IcalSubscriptionModeTransparent && s.intersectsTargets(courseTagIDs)
+}
+
+// IsExcluded は指定したタグ ID を持つコースをフィードから除外すべきかを返す。
+func (s *IcalSubscription) IsExcluded(courseTagIDs []idtype.TagID) bool {
+	return s.Mode == IcalSubscriptionModeExclude && s.intersectsTargets(courseTagIDs)
+}
+
+func (s *IcalSubscription) intersectsTargets(courseTagIDs []idtype.TagID) bool {
+	if len(s.TargetTagIDs) == 0 || len(courseTagIDs) == 0 {
+		return false
+	}
+	targets := make(map[idtype.TagID]struct{}, len(s.TargetTagIDs))
+	for _, t := range s.TargetTagIDs {
+		targets[t] = struct{}{}
+	}
+	for _, t := range courseTagIDs {
+		if _, ok := targets[t]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/back/module/calendar/module.go
+++ b/back/module/calendar/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/samber/mo"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 )
@@ -25,18 +26,24 @@ type UseCase interface {
 	// [Authentication] not required
 	ExportTimetableToICalByIcalSubscriptionID(ctx context.Context, id idtype.IcalSubscriptionID, year shareddomain.AcademicYear, tagIDs []idtype.TagID, isRdateSupported bool) ([]byte, error)
 
-	// FindIcalSubscriptionID returns the iCal subscription ID if the user has enabled it.
+	// FindIcalSubscription はユーザーが連携を有効化していれば iCal 連携（id, mode, 対象タグ ID）を返す。
 	//
 	// [Authentication] required
-	FindIcalSubscriptionID(ctx context.Context) (mo.Option[idtype.IcalSubscriptionID], error)
+	FindIcalSubscription(ctx context.Context) (mo.Option[*calendardomain.IcalSubscription], error)
 
-	// EnableIcalSubscription creates or returns the iCal subscription ID for the user.
+	// EnableIcalSubscription はユーザーの iCal 連携 ID を作成または既存のものを返す。
+	// 新規作成時のモードは SYNC、対象タグは空がデフォルト。
 	//
 	// [Authentication] required
 	EnableIcalSubscription(ctx context.Context) (idtype.IcalSubscriptionID, error)
 
-	// DisableIcalSubscription removes the public iCal URL for the user.
+	// DisableIcalSubscription はユーザーの公開 iCal URL を削除する。
 	//
 	// [Authentication] required
 	DisableIcalSubscription(ctx context.Context) error
+
+	// UpdateIcalSubscription はユーザーの iCal 連携のモードと対象タグ ID を上書きする。
+	//
+	// [Authentication] required
+	UpdateIcalSubscription(ctx context.Context, mode calendardomain.IcalSubscriptionMode, targetTagIDs []idtype.TagID) error
 }

--- a/back/module/calendar/port/repository.go
+++ b/back/module/calendar/port/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/samber/mo"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 	sharedport "github.com/twin-te/twin-te/back/module/shared/port"
 )
@@ -11,8 +12,9 @@ import (
 type Repository interface {
 	Transaction(ctx context.Context, fn func(rtx Repository) error, readOnly bool) error
 
-	FindUserByIcalSubscriptionID(ctx context.Context, id idtype.IcalSubscriptionID, lock sharedport.Lock) (mo.Option[idtype.UserID], error)
-	FindIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID, lock sharedport.Lock) (mo.Option[idtype.IcalSubscriptionID], error)
-	CreateIcalSubscription(ctx context.Context, id idtype.IcalSubscriptionID, userID idtype.UserID) error
+	FindIcalSubscriptionByID(ctx context.Context, id idtype.IcalSubscriptionID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error)
+	FindIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID, lock sharedport.Lock) (mo.Option[*calendardomain.IcalSubscription], error)
+	CreateIcalSubscription(ctx context.Context, s *calendardomain.IcalSubscription) error
+	UpdateIcalSubscription(ctx context.Context, s *calendardomain.IcalSubscription) error
 	DeleteIcalSubscriptionByUserID(ctx context.Context, userID idtype.UserID) (rowsAffected int, err error)
 }

--- a/back/module/calendar/usecase/ical_export.go
+++ b/back/module/calendar/usecase/ical_export.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/samber/mo"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	shareddomain "github.com/twin-te/twin-te/back/module/shared/domain"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 	timetableappdto "github.com/twin-te/twin-te/back/module/timetable/appdto"
@@ -37,19 +38,19 @@ func (uc *impl) ExportTimetableToICal(ctx context.Context, year shareddomain.Aca
 		return nil, err
 	}
 
-	return uc.exportTimetableToICalByUserID(ctx, userID, year, tagIDs, isRdateSupported)
+	return uc.exportTimetableToICalByUserID(ctx, userID, year, tagIDs, nil, isRdateSupported)
 }
 
 func (uc *impl) ExportTimetableToICalByIcalSubscriptionID(ctx context.Context, id idtype.IcalSubscriptionID, year shareddomain.AcademicYear, tagIDs []idtype.TagID, isRdateSupported bool) ([]byte, error) {
-	userID, err := uc.resolveUserIDByIcalSubscriptionID(ctx, id)
+	sub, err := uc.resolveIcalSubscriptionByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	return uc.exportTimetableToICalByUserID(ctx, userID, year, tagIDs, isRdateSupported)
+	return uc.exportTimetableToICalByUserID(ctx, sub.UserID, year, tagIDs, sub, isRdateSupported)
 }
 
-func (uc *impl) exportTimetableToICalByUserID(ctx context.Context, userID idtype.UserID, year shareddomain.AcademicYear, tagIDs []idtype.TagID, isRdateSupported bool) ([]byte, error) {
+func (uc *impl) exportTimetableToICalByUserID(ctx context.Context, userID idtype.UserID, year shareddomain.AcademicYear, tagIDs []idtype.TagID, sub *calendardomain.IcalSubscription, isRdateSupported bool) ([]byte, error) {
 	modules, err := uc.buildSchoolCalendarModules(ctx, year)
 	if err != nil {
 		return nil, err
@@ -63,12 +64,39 @@ func (uc *impl) exportTimetableToICalByUserID(ctx context.Context, userID idtype
 		return nil, err
 	}
 
+	// ?tags[]= クエリパラメータは包含フィルタとして先に適用する。
 	courses = filterCoursesByTags(courses, tagIDs)
 
+	// 連携のモード（EXCLUDE / TRANSPARENT）は包含フィルタの後段で適用する。
+	courses, transparentCourseIDs := applyIcalSubscriptionMode(courses, sub)
+
 	var buf bytes.Buffer
-	if err := uc.writeICalendar(&buf, modules, courses, isRdateSupported); err != nil {
+	if err := uc.writeICalendar(&buf, modules, courses, transparentCourseIDs, isRdateSupported); err != nil {
 		return nil, err
 	}
 
 	return buf.Bytes(), nil
+}
+
+// applyIcalSubscriptionMode は連携のモードをコース一覧に適用する。
+//   - EXCLUDE: タグが対象タグと交差するコースを除外する。
+//   - TRANSPARENT: 該当コースは残しつつ、TRANSP:TRANSPARENT を付与できるよう返却用の集合に記録する。
+//   - SYNC / 連携が nil（認証ユーザーによる直接エクスポート）: コースをそのまま返す。
+func applyIcalSubscriptionMode(courses []*timetableappdto.RegisteredCourse, sub *calendardomain.IcalSubscription) ([]*timetableappdto.RegisteredCourse, map[idtype.RegisteredCourseID]struct{}) {
+	if sub == nil || sub.Mode == calendardomain.IcalSubscriptionModeSync {
+		return courses, nil
+	}
+
+	transparent := make(map[idtype.RegisteredCourseID]struct{})
+	filtered := make([]*timetableappdto.RegisteredCourse, 0, len(courses))
+	for _, c := range courses {
+		if sub.IsExcluded(c.TagIDs) {
+			continue
+		}
+		if sub.IsTransparent(c.TagIDs) {
+			transparent[c.ID] = struct{}{}
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered, transparent
 }

--- a/back/module/calendar/usecase/ical_subscription.go
+++ b/back/module/calendar/usecase/ical_subscription.go
@@ -3,26 +3,23 @@ package calendarusecase
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/twin-te/twin-te/back/apperr"
+	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
 	calendarport "github.com/twin-te/twin-te/back/module/calendar/port"
 	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 	sharederr "github.com/twin-te/twin-te/back/module/shared/err"
 	sharedport "github.com/twin-te/twin-te/back/module/shared/port"
 )
 
-func (uc *impl) FindIcalSubscriptionID(ctx context.Context) (mo.Option[idtype.IcalSubscriptionID], error) {
+func (uc *impl) FindIcalSubscription(ctx context.Context) (mo.Option[*calendardomain.IcalSubscription], error) {
 	userID, err := uc.a.Authenticate(ctx)
 	if err != nil {
-		return mo.None[idtype.IcalSubscriptionID](), err
+		return mo.None[*calendardomain.IcalSubscription](), err
 	}
 
-	subID, err := uc.r.FindIcalSubscriptionByUserID(ctx, userID, sharedport.LockNone)
-	if err != nil {
-		return mo.None[idtype.IcalSubscriptionID](), err
-	}
-
-	return subID, nil
+	return uc.r.FindIcalSubscriptionByUserID(ctx, userID, sharedport.LockNone)
 }
 
 func (uc *impl) EnableIcalSubscription(ctx context.Context) (idtype.IcalSubscriptionID, error) {
@@ -37,12 +34,22 @@ func (uc *impl) EnableIcalSubscription(ctx context.Context) (idtype.IcalSubscrip
 		if err != nil {
 			return err
 		}
-		if existing.IsPresent() {
-			resultID, _ = existing.Get()
+		if sub, ok := existing.Get(); ok {
+			resultID = sub.ID
 			return nil
 		}
-		resultID = idtype.NewIcalSubscriptionID()
-		return rtx.CreateIcalSubscription(ctx, resultID, userID)
+
+		sub, err := calendardomain.ConstructIcalSubscription(func(s *calendardomain.IcalSubscription) error {
+			s.ID = idtype.NewIcalSubscriptionID()
+			s.UserID = userID
+			s.Mode = calendardomain.IcalSubscriptionModeSync
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		resultID = sub.ID
+		return rtx.CreateIcalSubscription(ctx, sub)
 	}, false)
 	if err != nil {
 		return idtype.IcalSubscriptionID{}, err
@@ -59,16 +66,58 @@ func (uc *impl) DisableIcalSubscription(ctx context.Context) error {
 	return err
 }
 
-func (uc *impl) resolveUserIDByIcalSubscriptionID(ctx context.Context, id idtype.IcalSubscriptionID) (idtype.UserID, error) {
-	optUserID, err := uc.r.FindUserByIcalSubscriptionID(ctx, id, sharedport.LockNone)
+func (uc *impl) UpdateIcalSubscription(ctx context.Context, mode calendardomain.IcalSubscriptionMode, targetTagIDs []idtype.TagID) error {
+	userID, err := uc.a.Authenticate(ctx)
 	if err != nil {
-		return idtype.UserID{}, err
+		return err
 	}
 
-	userID, ok := optUserID.Get()
+	// トランザクションを開始する前に、対象タグ ID がすべてユーザー所有であることを検証する。
+	if len(targetTagIDs) != 0 {
+		ownedTagIDs, err := uc.timetable.ListTagIDsByUserID(ctx, userID, targetTagIDs)
+		if err != nil {
+			return err
+		}
+		if notOwned, _ := lo.Difference(targetTagIDs, ownedTagIDs); len(notOwned) != 0 {
+			return sharederr.NewInvalidArgument("invalid tag ids %+v", notOwned)
+		}
+	}
+
+	return uc.r.Transaction(ctx, func(rtx calendarport.Repository) error {
+		existing, err := rtx.FindIcalSubscriptionByUserID(ctx, userID, sharedport.LockExclusive)
+		if err != nil {
+			return err
+		}
+		sub, ok := existing.Get()
+		if !ok {
+			return apperr.New(sharederr.CodeInvalidArgument, "ical subscription is not enabled")
+		}
+
+		updated, err := calendardomain.ConstructIcalSubscription(func(s *calendardomain.IcalSubscription) error {
+			s.ID = sub.ID
+			s.UserID = sub.UserID
+			s.Mode = mode
+			s.TargetTagIDs = targetTagIDs
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		return rtx.UpdateIcalSubscription(ctx, updated)
+	}, false)
+}
+
+func (uc *impl) resolveIcalSubscriptionByID(ctx context.Context, id idtype.IcalSubscriptionID) (*calendardomain.IcalSubscription, error) {
+	optSub, err := uc.r.FindIcalSubscriptionByID(ctx, id, sharedport.LockNone)
+	if err != nil {
+		return nil, err
+	}
+
+	sub, ok := optSub.Get()
 	if !ok {
-		return idtype.UserID{}, apperr.New(sharederr.CodeUnauthenticated, "invalid token")
+		return nil, apperr.New(sharederr.CodeUnauthenticated, "invalid token")
 	}
 
-	return userID, nil
+	return sub, nil
 }

--- a/back/module/calendar/usecase/ics.go
+++ b/back/module/calendar/usecase/ics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/twin-te/twin-te/back/appenv"
 	calendardomain "github.com/twin-te/twin-te/back/module/calendar/domain"
+	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
 	timetableappdto "github.com/twin-te/twin-te/back/module/timetable/appdto"
 )
 
@@ -50,7 +51,7 @@ func (w *errWriter) write(format string, a ...any) {
 	_, w.err = fmt.Fprintf(w.w, format+"\r\n", a...)
 }
 
-func (uc *impl) writeICalendar(writer io.Writer, modules []calendardomain.SchoolCalendarModule, courses []*timetableappdto.RegisteredCourse, isRdateSupported bool) error {
+func (uc *impl) writeICalendar(writer io.Writer, modules []calendardomain.SchoolCalendarModule, courses []*timetableappdto.RegisteredCourse, transparentCourseIDs map[idtype.RegisteredCourseID]struct{}, isRdateSupported bool) error {
 	w := &errWriter{w: writer}
 
 	w.write("BEGIN:VCALENDAR")
@@ -70,9 +71,10 @@ func (uc *impl) writeICalendar(writer io.Writer, modules []calendardomain.School
 	w.write("END:VTIMEZONE")
 
 	for _, c := range courses {
+		_, transparent := transparentCourseIDs[c.ID]
 		ss := calendardomain.GetSchedules(modules, c.Schedules)
 		for _, s := range ss {
-			writeCalendarEvent(w, c, s, isRdateSupported)
+			writeCalendarEvent(w, c, s, transparent, isRdateSupported)
 		}
 	}
 
@@ -97,11 +99,15 @@ func buildDescription(c *timetableappdto.RegisteredCourse) string {
 	return url
 }
 
-func writeCalendarEvent(w *errWriter, c *timetableappdto.RegisteredCourse, s calendardomain.Schedule, isRdateSupported bool) {
+func writeCalendarEvent(w *errWriter, c *timetableappdto.RegisteredCourse, s calendardomain.Schedule, transparent bool, isRdateSupported bool) {
 	w.write("BEGIN:VEVENT")
 
 	w.write("DTSTAMP:%s", icsDtstamp())
 	w.write("UID:%s", generateUID(c, s))
+
+	if transparent {
+		w.write("TRANSP:TRANSPARENT")
+	}
 
 	w.write("SUMMARY:%s", icsTextEscaper.Replace(c.Name.String()))
 	w.write("LOCATION:%s", icsTextEscaper.Replace(s.Location))
@@ -133,6 +139,10 @@ func writeCalendarEvent(w *errWriter, c *timetableappdto.RegisteredCourse, s cal
 
 			w.write("UID:%s", generateUID(c, newSchedule))
 			w.write("DTSTAMP:%s", icsDtstamp())
+
+			if transparent {
+				w.write("TRANSP:TRANSPARENT")
+			}
 
 			w.write("SUMMARY:%s", icsTextEscaper.Replace(c.Name.String()))
 			w.write("LOCATION:%s", icsTextEscaper.Replace(s.Location))

--- a/back/module/timetable/adapter/query/tag.go
+++ b/back/module/timetable/adapter/query/tag.go
@@ -1,0 +1,31 @@
+package timetablequery
+
+import (
+	"context"
+
+	"github.com/twin-te/twin-te/back/base"
+	"github.com/twin-te/twin-te/back/module/shared/domain/idtype"
+	timetabledbmodel "github.com/twin-te/twin-te/back/module/timetable/dbmodel"
+	"gorm.io/gorm"
+)
+
+func (q *impl) ListTagIDsByUserID(ctx context.Context, userID idtype.UserID, ids []idtype.TagID) ([]idtype.TagID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var dbTags []*timetabledbmodel.Tag
+	if err := q.gormTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.
+			Where("user_id = ?", userID.String()).
+			Where("id IN ?", base.MapByString(ids)).
+			Find(&dbTags).
+			Error
+	}); err != nil {
+		return nil, err
+	}
+
+	return base.MapWithErr(dbTags, func(dbTag *timetabledbmodel.Tag) (idtype.TagID, error) {
+		return idtype.ParseTagID(dbTag.ID)
+	})
+}

--- a/back/module/timetable/port/query.go
+++ b/back/module/timetable/port/query.go
@@ -12,6 +12,10 @@ import (
 type Query interface {
 	FindRegisteredCourses(ctx context.Context, id idtype.RegisteredCourseID) (mo.Option[*timetableappdto.RegisteredCourse], error)
 	ListRegisteredCourses(ctx context.Context, conds ListRegisteredCoursesConds) ([]*timetableappdto.RegisteredCourse, error)
+
+	// ListTagIDsByUserID は ids のうち userID が所有するタグ ID を返す。
+	// あるタグ ID 集合がユーザーの所有かどうかを検証するために用いる。
+	ListTagIDsByUserID(ctx context.Context, userID idtype.UserID, ids []idtype.TagID) ([]idtype.TagID, error)
 }
 
 type ListRegisteredCoursesConds struct {

--- a/db/migrations/000004_add_ical_subscription_mode_and_target_tags.down.sql
+++ b/db/migrations/000004_add_ical_subscription_mode_and_target_tags.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP TABLE IF EXISTS ical_subscription_target_tags;
+
+ALTER TABLE ical_subscriptions
+    DROP COLUMN IF EXISTS mode;
+
+COMMIT;

--- a/db/migrations/000004_add_ical_subscription_mode_and_target_tags.up.sql
+++ b/db/migrations/000004_add_ical_subscription_mode_and_target_tags.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE ical_subscriptions
+    ADD COLUMN mode text NOT NULL DEFAULT 'sync';
+
+CREATE TABLE ical_subscription_target_tags (
+    ical_subscription_id uuid NOT NULL,
+    tag_id uuid NOT NULL,
+    PRIMARY KEY (ical_subscription_id, tag_id),
+    FOREIGN KEY (ical_subscription_id) REFERENCES ical_subscriptions(id) ON DELETE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+);
+
+COMMIT;

--- a/proto/calendar/v1/service.proto
+++ b/proto/calendar/v1/service.proto
@@ -2,9 +2,21 @@ syntax = "proto3";
 package calendar.v1;
 
 import "shared/option.proto";
+import "shared/type.proto";
 
 option go_package = "github.com/twin-te/twin-te/back/handler/api/v4/rpcgen/calendar/v1;calendarv1";
 option java_package = "net.twinte.api.calendar.v1";
+
+// IcalSubscriptionMode は target_tag_ids が付与されたコースを iCal フィードでどう出力するかを制御する。
+enum IcalSubscriptionMode {
+  ICAL_SUBSCRIPTION_MODE_UNSPECIFIED = 0;
+  // SYNC はすべてのコースを通常出力する。target_tag_ids は空でなければならない。
+  ICAL_SUBSCRIPTION_MODE_SYNC = 1;
+  // EXCLUDE は target_tag_ids のいずれかのタグを持つコースを出力しない。
+  ICAL_SUBSCRIPTION_MODE_EXCLUDE = 2;
+  // TRANSPARENT は target_tag_ids のいずれかのタグを持つコースに TRANSP:TRANSPARENT を付与する。
+  ICAL_SUBSCRIPTION_MODE_TRANSPARENT = 3;
+}
 
 // The following error codes are not stated explicitly in the each rpc, but may be returned.
 //   - shared.InvalidArgument
@@ -32,12 +44,22 @@ service CalendarService {
       error_codes: []
     };
   }
+
+  rpc UpdateIcalSubscription(UpdateIcalSubscriptionRequest) returns (UpdateIcalSubscriptionResponse) {
+    option (shared.twinte) = {
+      authentication: REQURED
+      error_codes: []
+    };
+  }
 }
 
 message GetIcalSubscriptionUrlRequest {}
 
 message GetIcalSubscriptionUrlResponse {
   optional string url = 1;
+  // mode と target_tag_ids は現在の設定を表す。url が設定されているときのみ意味を持つ。
+  IcalSubscriptionMode mode = 2;
+  repeated shared.UUID target_tag_ids = 3;
 }
 
 message EnableIcalSubscriptionRequest {}
@@ -49,3 +71,10 @@ message EnableIcalSubscriptionResponse {
 message DisableIcalSubscriptionRequest {}
 
 message DisableIcalSubscriptionResponse {}
+
+message UpdateIcalSubscriptionRequest {
+  IcalSubscriptionMode mode = 1;
+  repeated shared.UUID target_tag_ids = 2;
+}
+
+message UpdateIcalSubscriptionResponse {}


### PR DESCRIPTION
## 概要

closes #433

カレンダー連携（iCal購読）で、特定タグを付けた科目を**除外**または**予定なし扱い（`TRANSP:TRANSPARENT`）**にできるようにします。`IcalSubscription` に同期モード `mode` と対象タグ集合 `targetTagIDs` を持たせ、配信時に適用します。

**今回はバックエンドのみ**です。フロント（`settings.vue` のタグ選択・モード選択UI）は別対応とします。

### モードの適用ルール（配信時）

| `mode` | 対象タグを持つ科目の扱い |
| --- | --- |
| `SYNC` | 通常出力（`targetTagIDs` は常に空） |
| `EXCLUDE` | 科目のタグ ∩ `targetTagIDs` ≠ ∅ なら出力しない |
| `TRANSPARENT` | 上記の交差があれば `TRANSP:TRANSPARENT` を付与 |

不変条件: `mode == SYNC` のとき `targetTagIDs` は空集合 / 同一ユーザー所有のタグのみ / 重複なし。

## 変更内容

- **proto**: `IcalSubscriptionMode` enum 追加、`GetIcalSubscriptionUrl` に `mode`/`target_tag_ids` 追加、`UpdateIcalSubscription` RPC 追加
- **DB**: マイグレーション 000004（`mode` カラム ＋ `ical_subscription_target_tags` 中間テーブル）。`tags(id)` への FK `ON DELETE CASCADE` により、タグ削除時に対象タグ集合から自動除去される
- **domain**: `IcalSubscription` エンティティを新設し不変条件を強制
- **usecase**: 配信時にモード適用、更新時にタグ所有者を検証（`?tags[]=` 包含フィルタは後方互換のため温存し、その後段でモード適用）
- **handler**: 現在設定の返却、`UpdateIcalSubscription` 実装

## 検証

- `make buf-gen` ＋ `go build ./...` 成功、`go vet` / `go test`（対象パッケージ）成功
- マイグレーション SQL を稼働中の dev DB スキーマに対しトランザクション内で適用し、FK/PK が正常生成されることを確認（ロールバック済み）

## レビュー観点 / 相談

- `FindUserByIcalSubscriptionID` を `FindIcalSubscriptionByID`（エンティティ返却）に改名しています。配信判定に `mode`/`targetTagIDs` が必要になり戻り値の型を変えたための改名です。命名方針について意見があれば。

🤖 Generated with [Claude Code](https://claude.com/claude-code)