### PR TITLE
feat(front): カレンダー連携で特定タグの科目を除外/「予定なし」にする設定UI (#433)

### DIFF
--- a/front/src/domain/calendar.ts
+++ b/front/src/domain/calendar.ts
@@ -1,0 +1,13 @@
+/**
+ * iCal 購読でタグの付いたコースをどう出力するか。
+ * - sync: そのまま同期する（対象タグは空）
+ * - exclude: 対象タグを持つコースをカレンダーに入れない
+ * - transparent: 対象タグを持つコースを「予定なし」（TRANSP:TRANSPARENT）にする
+ */
+export type IcalSubscriptionMode = "sync" | "exclude" | "transparent";
+
+export type IcalSubscription = {
+  url: string;
+  mode: IcalSubscriptionMode;
+  targetTagIds: string[];
+};

--- a/front/src/infrastructure/api/converters/calendarv1.ts
+++ b/front/src/infrastructure/api/converters/calendarv1.ts
@@ -1,0 +1,31 @@
+import { IcalSubscriptionMode } from "~/domain/calendar";
+import * as CalendarV1PB from "~/infrastructure/api/gen/calendar/v1/service_pb";
+
+export const fromPBIcalSubscriptionMode = (
+  pbMode: CalendarV1PB.IcalSubscriptionMode
+): IcalSubscriptionMode => {
+  switch (pbMode) {
+    // url が未設定のとき mode は UNSPECIFIED になりうるので sync 扱いにする。
+    case CalendarV1PB.IcalSubscriptionMode.UNSPECIFIED:
+    case CalendarV1PB.IcalSubscriptionMode.SYNC:
+      return "sync";
+    case CalendarV1PB.IcalSubscriptionMode.EXCLUDE:
+      return "exclude";
+    case CalendarV1PB.IcalSubscriptionMode.TRANSPARENT:
+      return "transparent";
+  }
+  throw Error(`invalid enum ${pbMode}`);
+};
+
+export const toPBIcalSubscriptionMode = (
+  mode: IcalSubscriptionMode
+): CalendarV1PB.IcalSubscriptionMode => {
+  switch (mode) {
+    case "sync":
+      return CalendarV1PB.IcalSubscriptionMode.SYNC;
+    case "exclude":
+      return CalendarV1PB.IcalSubscriptionMode.EXCLUDE;
+    case "transparent":
+      return CalendarV1PB.IcalSubscriptionMode.TRANSPARENT;
+  }
+};

--- a/front/src/infrastructure/api/gen/calendar/v1/service_connect.ts
+++ b/front/src/infrastructure/api/gen/calendar/v1/service_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { DisableIcalSubscriptionRequest, DisableIcalSubscriptionResponse, EnableIcalSubscriptionRequest, EnableIcalSubscriptionResponse, GetIcalSubscriptionUrlRequest, GetIcalSubscriptionUrlResponse } from "./service_pb.js";
+import { DisableIcalSubscriptionRequest, DisableIcalSubscriptionResponse, EnableIcalSubscriptionRequest, EnableIcalSubscriptionResponse, GetIcalSubscriptionUrlRequest, GetIcalSubscriptionUrlResponse, UpdateIcalSubscriptionRequest, UpdateIcalSubscriptionResponse } from "./service_pb.js";
 import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -43,6 +43,15 @@ export const CalendarService = {
       name: "DisableIcalSubscription",
       I: DisableIcalSubscriptionRequest,
       O: DisableIcalSubscriptionResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc calendar.v1.CalendarService.UpdateIcalSubscription
+     */
+    updateIcalSubscription: {
+      name: "UpdateIcalSubscription",
+      I: UpdateIcalSubscriptionRequest,
+      O: UpdateIcalSubscriptionResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/front/src/infrastructure/api/gen/calendar/v1/service_pb.ts
+++ b/front/src/infrastructure/api/gen/calendar/v1/service_pb.ts
@@ -5,6 +5,47 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3 } from "@bufbuild/protobuf";
+import { UUID } from "../../shared/type_pb.js";
+
+/**
+ * IcalSubscriptionMode は target_tag_ids が付与されたコースを iCal フィードでどう出力するかを制御する。
+ *
+ * @generated from enum calendar.v1.IcalSubscriptionMode
+ */
+export enum IcalSubscriptionMode {
+  /**
+   * @generated from enum value: ICAL_SUBSCRIPTION_MODE_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * SYNC はすべてのコースを通常出力する。target_tag_ids は空でなければならない。
+   *
+   * @generated from enum value: ICAL_SUBSCRIPTION_MODE_SYNC = 1;
+   */
+  SYNC = 1,
+
+  /**
+   * EXCLUDE は target_tag_ids のいずれかのタグを持つコースを出力しない。
+   *
+   * @generated from enum value: ICAL_SUBSCRIPTION_MODE_EXCLUDE = 2;
+   */
+  EXCLUDE = 2,
+
+  /**
+   * TRANSPARENT は target_tag_ids のいずれかのタグを持つコースに TRANSP:TRANSPARENT を付与する。
+   *
+   * @generated from enum value: ICAL_SUBSCRIPTION_MODE_TRANSPARENT = 3;
+   */
+  TRANSPARENT = 3,
+}
+// Retrieve enum metadata with: proto3.getEnumType(IcalSubscriptionMode)
+proto3.util.setEnumType(IcalSubscriptionMode, "calendar.v1.IcalSubscriptionMode", [
+  { no: 0, name: "ICAL_SUBSCRIPTION_MODE_UNSPECIFIED" },
+  { no: 1, name: "ICAL_SUBSCRIPTION_MODE_SYNC" },
+  { no: 2, name: "ICAL_SUBSCRIPTION_MODE_EXCLUDE" },
+  { no: 3, name: "ICAL_SUBSCRIPTION_MODE_TRANSPARENT" },
+]);
 
 /**
  * @generated from message calendar.v1.GetIcalSubscriptionUrlRequest
@@ -46,6 +87,18 @@ export class GetIcalSubscriptionUrlResponse extends Message<GetIcalSubscriptionU
    */
   url?: string;
 
+  /**
+   * mode と target_tag_ids は現在の設定を表す。url が設定されているときのみ意味を持つ。
+   *
+   * @generated from field: calendar.v1.IcalSubscriptionMode mode = 2;
+   */
+  mode = IcalSubscriptionMode.UNSPECIFIED;
+
+  /**
+   * @generated from field: repeated shared.UUID target_tag_ids = 3;
+   */
+  targetTagIds: UUID[] = [];
+
   constructor(data?: PartialMessage<GetIcalSubscriptionUrlResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -55,6 +108,8 @@ export class GetIcalSubscriptionUrlResponse extends Message<GetIcalSubscriptionU
   static readonly typeName = "calendar.v1.GetIcalSubscriptionUrlResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "url", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 2, name: "mode", kind: "enum", T: proto3.getEnumType(IcalSubscriptionMode) },
+    { no: 3, name: "target_tag_ids", kind: "message", T: UUID, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetIcalSubscriptionUrlResponse {
@@ -201,6 +256,80 @@ export class DisableIcalSubscriptionResponse extends Message<DisableIcalSubscrip
 
   static equals(a: DisableIcalSubscriptionResponse | PlainMessage<DisableIcalSubscriptionResponse> | undefined, b: DisableIcalSubscriptionResponse | PlainMessage<DisableIcalSubscriptionResponse> | undefined): boolean {
     return proto3.util.equals(DisableIcalSubscriptionResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message calendar.v1.UpdateIcalSubscriptionRequest
+ */
+export class UpdateIcalSubscriptionRequest extends Message<UpdateIcalSubscriptionRequest> {
+  /**
+   * @generated from field: calendar.v1.IcalSubscriptionMode mode = 1;
+   */
+  mode = IcalSubscriptionMode.UNSPECIFIED;
+
+  /**
+   * @generated from field: repeated shared.UUID target_tag_ids = 2;
+   */
+  targetTagIds: UUID[] = [];
+
+  constructor(data?: PartialMessage<UpdateIcalSubscriptionRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "calendar.v1.UpdateIcalSubscriptionRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "mode", kind: "enum", T: proto3.getEnumType(IcalSubscriptionMode) },
+    { no: 2, name: "target_tag_ids", kind: "message", T: UUID, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateIcalSubscriptionRequest {
+    return new UpdateIcalSubscriptionRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateIcalSubscriptionRequest {
+    return new UpdateIcalSubscriptionRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateIcalSubscriptionRequest {
+    return new UpdateIcalSubscriptionRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateIcalSubscriptionRequest | PlainMessage<UpdateIcalSubscriptionRequest> | undefined, b: UpdateIcalSubscriptionRequest | PlainMessage<UpdateIcalSubscriptionRequest> | undefined): boolean {
+    return proto3.util.equals(UpdateIcalSubscriptionRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message calendar.v1.UpdateIcalSubscriptionResponse
+ */
+export class UpdateIcalSubscriptionResponse extends Message<UpdateIcalSubscriptionResponse> {
+  constructor(data?: PartialMessage<UpdateIcalSubscriptionResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "calendar.v1.UpdateIcalSubscriptionResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateIcalSubscriptionResponse {
+    return new UpdateIcalSubscriptionResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateIcalSubscriptionResponse {
+    return new UpdateIcalSubscriptionResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateIcalSubscriptionResponse {
+    return new UpdateIcalSubscriptionResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateIcalSubscriptionResponse | PlainMessage<UpdateIcalSubscriptionResponse> | undefined, b: UpdateIcalSubscriptionResponse | PlainMessage<UpdateIcalSubscriptionResponse> | undefined): boolean {
+    return proto3.util.equals(UpdateIcalSubscriptionResponse, a, b);
   }
 }
 

--- a/front/src/ui/components/IcalDetailSettings.vue
+++ b/front/src/ui/components/IcalDetailSettings.vue
@@ -15,9 +15,9 @@ type Behavior = {
 };
 
 const behaviors: Behavior[] = [
-  { mode: "sync", title: "そのまま", description: "ふつうに表示" },
-  { mode: "exclude", title: "入れない", description: "カレンダーから消す" },
-  { mode: "transparent", title: "予定なし", description: "時間を空けておく" },
+  { mode: "sync", title: "そのまま", description: "通常の予定として表示されます" },
+  { mode: "exclude", title: "入れない", description: "予定を表示しません" },
+  { mode: "transparent", title: "予定なし", description: "空き時間として表示されます" },
 ];
 
 export default defineComponent({
@@ -218,7 +218,6 @@ export default defineComponent({
     padding: 0.6rem;
     border-radius: $radius-2;
     background: getColor(--color-base);
-    box-shadow: $shadow-primary-concave;
   }
 
   &__cell {
@@ -259,7 +258,7 @@ export default defineComponent({
   &__labels {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.5rem;
   }
 
   &__title {

--- a/front/src/ui/components/IcalDetailSettings.vue
+++ b/front/src/ui/components/IcalDetailSettings.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
+import { IcalSubscriptionMode } from "~/domain/calendar";
 import Button from "./Button.vue";
 import Tag from "./Tag.vue";
-import { IcalSubscriptionMode } from "~/domain/calendar";
 
 export type IcalDetailSettingsValue = {
   mode: IcalSubscriptionMode;

--- a/front/src/ui/components/IcalDetailSettings.vue
+++ b/front/src/ui/components/IcalDetailSettings.vue
@@ -1,0 +1,281 @@
+<script lang="ts">
+import { computed, defineComponent, PropType } from "vue";
+import { IcalSubscriptionMode } from "~/domain/calendar";
+import Tag from "./Tag.vue";
+
+export type IcalDetailSettingsValue = {
+  mode: IcalSubscriptionMode;
+  targetTagIds: string[];
+};
+
+type Behavior = {
+  mode: IcalSubscriptionMode;
+  title: string;
+  description: string;
+};
+
+const behaviors: Behavior[] = [
+  { mode: "sync", title: "そのまま", description: "ふつうに表示" },
+  { mode: "exclude", title: "入れない", description: "カレンダーから消す" },
+  { mode: "transparent", title: "予定なし", description: "時間を空けておく" },
+];
+
+export default defineComponent({
+  name: "IcalDetailSettings",
+  components: { Tag },
+  props: {
+    modelValue: {
+      type: Object as PropType<IcalDetailSettingsValue>,
+      required: true,
+    },
+    tags: {
+      type: Array as PropType<{ id: string; name: string }[]>,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+  setup(props, { emit }) {
+    const selectedTagIds = computed(() => props.modelValue.targetTagIds);
+    const mode = computed(() => props.modelValue.mode);
+
+    const isTagSelected = (id: string) => selectedTagIds.value.includes(id);
+
+    const onClickTag = (id: string) => {
+      const next = isTagSelected(id)
+        ? selectedTagIds.value.filter((tagId) => tagId !== id)
+        : [...selectedTagIds.value, id];
+      emit("update:modelValue", { mode: mode.value, targetTagIds: next });
+    };
+
+    const onSelectMode = (next: IcalSubscriptionMode) => {
+      emit("update:modelValue", {
+        mode: next,
+        targetTagIds: selectedTagIds.value,
+      });
+    };
+
+    return { behaviors, mode, isTagSelected, onClickTag, onSelectMode };
+  },
+});
+</script>
+
+<template>
+  <div class="ical-detail-settings">
+    <p class="ical-detail-settings__description">
+      タグのついた授業を、連携カレンダーにどう出すか設定できます。
+    </p>
+
+    <section class="ical-detail-settings__section">
+      <h3 class="ical-detail-settings__heading">対象のタグ</h3>
+      <p v-if="tags.length === 0" class="ical-detail-settings__empty">
+        タグがまだありません。授業にタグを付けると、ここで選べるようになります。
+      </p>
+      <div v-else class="ical-detail-settings__tags">
+        <Tag
+          v-for="tag in tags"
+          :key="tag.id"
+          :assign="isTagSelected(tag.id)"
+          @click="() => onClickTag(tag.id)"
+          >{{ tag.name }}</Tag
+        >
+      </div>
+    </section>
+
+    <section class="ical-detail-settings__section">
+      <h3 class="ical-detail-settings__heading">対象タグの挙動</h3>
+      <div class="ical-detail-settings__cards">
+        <button
+          v-for="behavior in behaviors"
+          :key="behavior.mode"
+          type="button"
+          :class="{
+            card: true,
+            '--selected': mode === behavior.mode,
+          }"
+          @click="() => onSelectMode(behavior.mode)"
+        >
+          <span v-if="mode === behavior.mode" class="material-icons card__check"
+            >check_circle</span
+          >
+          <div class="card__preview">
+            <span class="card__cell"></span>
+            <span
+              :class="`card__cell card__cell--main card__cell--${behavior.mode}`"
+            >
+              <template v-if="behavior.mode === 'sync'">授業</template>
+              <template v-else-if="behavior.mode === 'transparent'"
+                >空き</template
+              >
+            </span>
+            <span class="card__cell"></span>
+            <span class="card__cell"></span>
+            <span class="card__cell"></span>
+            <span class="card__cell"></span>
+            <span class="card__cell"></span>
+            <span class="card__cell"></span>
+          </div>
+          <div class="card__labels">
+            <span class="card__title">{{ behavior.title }}</span>
+            <span class="card__description">{{ behavior.description }}</span>
+          </div>
+        </button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@import "~/ui/styles";
+
+.ical-detail-settings {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-6;
+
+  &__description {
+    @include text-discription;
+    color: getColor(--color-text-sub);
+    line-height: $single-line;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-3;
+  }
+
+  &__heading {
+    font-size: $font-small;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: getColor(--color-text-sub);
+  }
+
+  &__empty {
+    @include text-discription;
+    color: getColor(--color-text-sub);
+    line-height: $single-line;
+  }
+
+  &__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2;
+  }
+
+  &__cards {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-3;
+    @include large-screen {
+      flex-direction: row;
+    }
+  }
+}
+
+.card {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-3 $spacing-4;
+  border: none;
+  border-radius: $radius-3;
+  background: getColor(--color-base);
+  box-shadow: $shadow-convex;
+  text-align: left;
+  @include button-cursor;
+
+  @include large-screen {
+    flex-direction: column;
+    text-align: center;
+    padding: $spacing-4 $spacing-3;
+  }
+
+  &.--selected {
+    box-shadow: $shadow-primary-concave;
+    outline: 0.2rem solid getColor(--color-primary);
+  }
+
+  &__check {
+    position: absolute;
+    top: -0.9rem;
+    right: -0.9rem;
+    font-size: 2.2rem;
+    color: getColor(--color-white);
+    background: var(--primary-liner);
+    border-radius: 50%;
+  }
+
+  &__preview {
+    flex-shrink: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1.6rem);
+    gap: 0.3rem;
+    width: 10.8rem;
+    padding: 0.6rem;
+    border-radius: $radius-2;
+    background: getColor(--color-base);
+    box-shadow: $shadow-primary-concave;
+  }
+
+  &__cell {
+    border-radius: 0.3rem;
+    background: #e2e6ed;
+
+    &--main {
+      grid-row: span 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      font-weight: 700;
+    }
+
+    &--sync {
+      background: var(--primary-liner);
+      color: getColor(--color-white);
+    }
+
+    &--exclude {
+      background: transparent;
+      border: 0.15rem dashed getColor(--color-unselected);
+    }
+
+    &--transparent {
+      color: getColor(--color-primary-dull);
+      background: repeating-linear-gradient(
+        45deg,
+        #c9eef0,
+        #c9eef0 0.3rem,
+        #eef7f8 0.3rem,
+        #eef7f8 0.6rem
+      );
+    }
+  }
+
+  &__labels {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  &__title {
+    font-size: $font-small;
+    font-weight: 700;
+    color: getColor(--color-text-main);
+  }
+
+  &.--selected &__title {
+    color: getColor(--color-primary);
+  }
+
+  &__description {
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: getColor(--color-text-sub);
+  }
+}
+</style>

--- a/front/src/ui/components/IcalDetailSettings.vue
+++ b/front/src/ui/components/IcalDetailSettings.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
-import { IcalSubscriptionMode } from "~/domain/calendar";
+import Button from "./Button.vue";
 import Tag from "./Tag.vue";
+import { IcalSubscriptionMode } from "~/domain/calendar";
 
 export type IcalDetailSettingsValue = {
   mode: IcalSubscriptionMode;
@@ -22,7 +23,7 @@ const behaviors: Behavior[] = [
 
 export default defineComponent({
   name: "IcalDetailSettings",
-  components: { Tag },
+  components: { Tag, Button },
   props: {
     modelValue: {
       type: Object as PropType<IcalDetailSettingsValue>,
@@ -33,10 +34,11 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: ["update:modelValue"],
+  emits: ["update:modelValue", "create-tag"],
   setup(props, { emit }) {
     const selectedTagIds = computed(() => props.modelValue.targetTagIds);
     const mode = computed(() => props.modelValue.mode);
+    const hasNoTags = computed(() => props.tags.length === 0);
 
     const isTagSelected = (id: string) => selectedTagIds.value.includes(id);
 
@@ -48,13 +50,21 @@ export default defineComponent({
     };
 
     const onSelectMode = (next: IcalSubscriptionMode) => {
+      if (hasNoTags.value) return;
       emit("update:modelValue", {
         mode: next,
         targetTagIds: selectedTagIds.value,
       });
     };
 
-    return { behaviors, mode, isTagSelected, onClickTag, onSelectMode };
+    return {
+      behaviors,
+      mode,
+      hasNoTags,
+      isTagSelected,
+      onClickTag,
+      onSelectMode,
+    };
   },
 });
 </script>
@@ -67,9 +77,18 @@ export default defineComponent({
 
     <section class="ical-detail-settings__section">
       <h3 class="ical-detail-settings__heading">対象のタグ</h3>
-      <p v-if="tags.length === 0" class="ical-detail-settings__empty">
-        タグがまだありません。授業にタグを付けると、ここで選べるようになります。
-      </p>
+      <div v-if="hasNoTags" class="ical-detail-settings__empty">
+        <p class="ical-detail-settings__empty-text">
+          タグがまだありません。授業にタグを付けると、ここで選べるようになります。
+        </p>
+        <Button
+          size="medium"
+          layout="fill"
+          color="primary"
+          @click="$emit('create-tag')"
+          >タグを作成</Button
+        >
+      </div>
       <div v-else class="ical-detail-settings__tags">
         <Tag
           v-for="tag in tags"
@@ -88,9 +107,11 @@ export default defineComponent({
           v-for="behavior in behaviors"
           :key="behavior.mode"
           type="button"
+          :disabled="hasNoTags"
           :class="{
             card: true,
             '--selected': mode === behavior.mode,
+            '--disabled': hasNoTags,
           }"
           @click="() => onSelectMode(behavior.mode)"
         >
@@ -152,6 +173,12 @@ export default defineComponent({
   }
 
   &__empty {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-3;
+  }
+
+  &__empty-text {
     @include text-discription;
     color: getColor(--color-text-sub);
     line-height: $single-line;
@@ -196,6 +223,12 @@ export default defineComponent({
   &.--selected {
     box-shadow: $shadow-primary-concave;
     outline: 0.2rem solid getColor(--color-primary);
+  }
+
+  &.--disabled {
+    opacity: 0.5;
+    box-shadow: none;
+    cursor: not-allowed;
   }
 
   &__check {

--- a/front/src/ui/components/IcalDetailSettings.vue
+++ b/front/src/ui/components/IcalDetailSettings.vue
@@ -16,9 +16,17 @@ type Behavior = {
 };
 
 const behaviors: Behavior[] = [
-  { mode: "sync", title: "そのまま", description: "通常の予定として表示されます" },
+  {
+    mode: "sync",
+    title: "そのまま",
+    description: "通常の予定として表示されます",
+  },
   { mode: "exclude", title: "入れない", description: "予定を表示しません" },
-  { mode: "transparent", title: "予定なし", description: "空き時間として表示されます" },
+  {
+    mode: "transparent",
+    title: "予定なし",
+    description: "空き時間として表示されます",
+  },
 ];
 
 export default defineComponent({

--- a/front/src/ui/hooks/useIcalDetailSettings.ts
+++ b/front/src/ui/hooks/useIcalDetailSettings.ts
@@ -1,0 +1,57 @@
+import { ref } from "vue";
+import { IcalSubscriptionMode } from "~/domain/calendar";
+import {
+  InternalServerError,
+  isResultError,
+  NetworkError,
+  UnauthenticatedError,
+} from "~/domain/error";
+import { calendarUseCase, timetableUseCase } from "~/usecases";
+import type { IcalDetailSettingsValue } from "~/ui/components/IcalDetailSettings.vue";
+
+/**
+ * iCal 購読の「タグごとの表示設定」の状態を読み込み・保存するための composable。
+ * PC のモーダルと SP のサブページの両方から利用する。
+ */
+export const useIcalDetailSettings = () => {
+  const tags = ref<{ id: string; name: string }[]>([]);
+  const value = ref<IcalDetailSettingsValue>({
+    mode: "sync",
+    targetTagIds: [],
+  });
+  const loaded = ref(false);
+
+  const load = async () => {
+    const [settings, tagList] = await Promise.all([
+      calendarUseCase.getIcalSubscriptionUrl(),
+      timetableUseCase.listTags(),
+    ]);
+
+    if (!isResultError(tagList)) {
+      tags.value = tagList
+        .sort((a, b) => a.order - b.order)
+        .map(({ id, name }) => ({ id, name }));
+    }
+
+    if (!isResultError(settings) && "url" in settings && settings.url) {
+      value.value = {
+        mode: settings.mode,
+        targetTagIds: settings.targetTagIds,
+      };
+    }
+
+    loaded.value = true;
+  };
+
+  const save = (): Promise<
+    null | UnauthenticatedError | NetworkError | InternalServerError
+  > => {
+    // 不変条件: 対象タグが無い場合は SYNC（そのまま同期）として保存する。
+    const mode: IcalSubscriptionMode =
+      value.value.targetTagIds.length === 0 ? "sync" : value.value.mode;
+    const targetTagIds = mode === "sync" ? [] : value.value.targetTagIds;
+    return calendarUseCase.updateIcalSubscription(mode, targetTagIds);
+  };
+
+  return { tags, value, loaded, load, save };
+};

--- a/front/src/ui/pages/settings.vue
+++ b/front/src/ui/pages/settings.vue
@@ -209,7 +209,11 @@ declare global {
     >
       <template #title>詳細設定</template>
       <template #contents>
-        <IcalDetailSettings v-model="icalDetail" :tags="icalTags" />
+        <IcalDetailSettings
+          v-model="icalDetail"
+          :tags="icalTags"
+          @create-tag="onCreateTag"
+        />
       </template>
       <template #button>
         <Button
@@ -223,6 +227,7 @@ declare global {
           size="medium"
           layout="fill"
           color="primary"
+          :state="icalTags.length === 0 ? 'disabled' : 'default'"
           @click="onSaveIcalDetail"
           >保存する</Button
         >
@@ -348,6 +353,11 @@ const openIcalDetail = async () => {
   } else {
     router.push("/settings/ical");
   }
+};
+
+const onCreateTag = () => {
+  closeIcalDetailModal();
+  router.push("/credit");
 };
 
 const onSaveIcalDetail = async () => {

--- a/front/src/ui/pages/settings.vue
+++ b/front/src/ui/pages/settings.vue
@@ -452,6 +452,21 @@ const confirmDeleteAccount = async () => {
   @include max-width;
 }
 
+.ical-detail-modal {
+  :deep(.modal--large) {
+    @include large-screen {
+      width: 64rem;
+    }
+  }
+  :deep(.modal__button) {
+    gap: $spacing-4;
+  }
+  :deep(.modal__contents) {
+    padding: 0 1.2rem 1rem;
+    margin: 0 -1.2rem;
+  }
+}
+
 .main {
   margin-top: $spacing-5;
   &__contents {
@@ -528,8 +543,6 @@ const confirmDeleteAccount = async () => {
         align-items: center;
         gap: 1.2rem;
         margin-top: 0.4rem;
-        padding-top: 1.6rem;
-        border-top: 0.1rem solid getColor(--color-unselected);
         &__text {
           display: flex;
           flex-direction: column;
@@ -546,6 +559,7 @@ const confirmDeleteAccount = async () => {
         }
         & .button {
           margin: 0 0 0 auto;
+          flex-shrink: 0;
         }
       }
     }

--- a/front/src/ui/pages/settings.vue
+++ b/front/src/ui/pages/settings.vue
@@ -132,6 +132,22 @@ declare global {
                 <li>一度機能を無効にするとURLが変更されます。</li>
               </ul>
             </div>
+            <div class="ical-advanced">
+              <div class="ical-advanced__text">
+                <p class="ical-advanced__title">タグごとの表示設定</p>
+                <p class="ical-advanced__desc">
+                  特定のタグの授業を隠す・予定なし扱いにできます。
+                </p>
+              </div>
+              <Button
+                class="button"
+                size="small"
+                color="primary"
+                :pauseActiveStyle="false"
+                @click="openIcalDetail"
+                >詳細設定</Button
+              >
+            </div>
           </div>
         </div>
         <div v-if="isAuthenticated" class="main__content--account">
@@ -185,10 +201,38 @@ declare global {
         >
       </template>
     </Modal>
+    <Modal
+      v-if="isIcalDetailModalVisible"
+      size="large"
+      class="ical-detail-modal"
+      @click="closeIcalDetailModal"
+    >
+      <template #title>詳細設定</template>
+      <template #contents>
+        <IcalDetailSettings v-model="icalDetail" :tags="icalTags" />
+      </template>
+      <template #button>
+        <Button
+          size="medium"
+          layout="fill"
+          color="base"
+          @click="closeIcalDetailModal"
+          >キャンセル</Button
+        >
+        <Button
+          size="medium"
+          layout="fill"
+          color="primary"
+          @click="onSaveIcalDetail"
+          >保存する</Button
+        >
+      </template>
+    </Modal>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useMediaQuery } from "@vueuse/core";
 import { useHead } from "@vueuse/head";
 import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -200,10 +244,12 @@ import {
 } from "~/domain/error";
 import { academicYears } from "~/domain/year";
 import Dropdown from "~/ui/components/Dropdown.vue";
+import IcalDetailSettings from "~/ui/components/IcalDetailSettings.vue";
 import IconButton from "~/ui/components/IconButton.vue";
 import Modal from "~/ui/components/Modal.vue";
 import PageHeader from "~/ui/components/PageHeader.vue";
 import ToggleSwitch from "~/ui/components/ToggleSwitch.vue";
+import { useIcalDetailSettings } from "~/ui/hooks/useIcalDetailSettings";
 import { useSwitch } from "~/ui/hooks/useSwitch";
 import { isiOS, isMobile } from "~/ui/ua";
 import { authUseCase, calendarUseCase } from "~/usecases";
@@ -272,6 +318,56 @@ const copyIcalUrl = async () => {
     displayToast("URLをコピーしました", { type: "primary" });
   } catch {
     displayToast("コピーに失敗しました", { type: "danger" });
+  }
+};
+
+/** ical detail settings (タグごとの表示設定) */
+const {
+  tags: icalTags,
+  value: icalDetail,
+  load: loadIcalDetail,
+  save: saveIcalDetail,
+} = useIcalDetailSettings();
+
+// PC ではモーダル、SP ではサブページで詳細設定を出す。
+// Modal が PC レイアウトに切り替わる large-screen の条件に合わせる。
+const isLargeScreen = useMediaQuery(
+  "(min-height: 860px), (orientation: landscape)"
+);
+
+const [
+  isIcalDetailModalVisible,
+  openIcalDetailModal,
+  closeIcalDetailModal,
+] = useSwitch(false);
+
+const openIcalDetail = async () => {
+  if (isLargeScreen.value) {
+    await loadIcalDetail();
+    openIcalDetailModal();
+  } else {
+    router.push("/settings/ical");
+  }
+};
+
+const onSaveIcalDetail = async () => {
+  const result = await saveIcalDetail();
+  if (!isResultError(result)) {
+    closeIcalDetailModal();
+    displayToast("表示設定を保存しました", { type: "primary" });
+  } else if (result instanceof UnauthenticatedError) {
+    displayToast(
+      "ログインの確認に失敗しました。お手数ですが、再度ログインした上でお試しいただけますと幸いです。",
+      { type: "danger" }
+    );
+    router.push("/login");
+  } else if (result instanceof NetworkError) {
+    displayToast(
+      "ネットワークエラーが発生しました。お使いの端末がインターネットに接続されているか、今一度確認ください。",
+      { type: "danger" }
+    );
+  } else if (result instanceof InternalServerError) {
+    displayToast("サーバーエラーが発生しました。", { type: "danger" });
   }
 };
 
@@ -425,6 +521,31 @@ const confirmDeleteAccount = async () => {
           list-style: disc inside;
           margin-bottom: 0.8rem;
           font-weight: 400;
+        }
+      }
+      .ical-advanced {
+        display: flex;
+        align-items: center;
+        gap: 1.2rem;
+        margin-top: 0.4rem;
+        padding-top: 1.6rem;
+        border-top: 0.1rem solid getColor(--color-unselected);
+        &__text {
+          display: flex;
+          flex-direction: column;
+          gap: 0.3rem;
+        }
+        &__title {
+          font-weight: 500;
+          color: getColor(--color-text-main);
+        }
+        &__desc {
+          font-size: $font-small;
+          font-weight: 400;
+          color: getColor(--color-text-sub);
+        }
+        & .button {
+          margin: 0 0 0 auto;
         }
       }
     }

--- a/front/src/ui/pages/settings/ical.vue
+++ b/front/src/ui/pages/settings/ical.vue
@@ -83,19 +83,30 @@ const onSave = async () => {
 @import "~/ui/styles";
 .ical-settings {
   @include max-width;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .main {
   margin-top: $spacing-5;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  width: calc(100% + 2rem);
+  padding: 0 1rem 100px;
+  margin-left: -1rem;
+  overflow-y: auto;
+  overflow-x: hidden;
   &__contents {
-    height: calc(#{$vh} - 14rem);
     overflow-y: auto;
-    padding: 0 1.2rem;
+    padding: 0 1.2rem 1rem;
     margin: 0 -1.2rem;
   }
   &__footer {
+    position: absolute;
+    bottom: 0;
+    width: calc(100% - 3rem);
     flex-shrink: 0;
     display: flex;
     padding: $spacing-4 0;

--- a/front/src/ui/pages/settings/ical.vue
+++ b/front/src/ui/pages/settings/ical.vue
@@ -13,7 +13,11 @@
     </PageHeader>
     <div class="main">
       <div class="main__contents">
-        <IcalDetailSettings v-model="value" :tags="tags" />
+        <IcalDetailSettings
+          v-model="value"
+          :tags="tags"
+          @create-tag="onCreateTag"
+        />
       </div>
       <div class="main__footer">
         <Button
@@ -21,6 +25,7 @@
           layout="fill"
           color="primary"
           :pauseActiveStyle="false"
+          :state="tags.length === 0 ? 'disabled' : 'default'"
           @click="onSave"
           >保存する</Button
         >
@@ -56,6 +61,10 @@ const { displayToast } = useToast();
 const { tags, value, load, save } = useIcalDetailSettings();
 
 onMounted(load);
+
+const onCreateTag = () => {
+  router.push("/credit");
+};
 
 const onSave = async () => {
   const result = await save();

--- a/front/src/ui/pages/settings/ical.vue
+++ b/front/src/ui/pages/settings/ical.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="ical-settings">
+    <PageHeader>
+      <template #left-button-icon>
+        <IconButton
+          size="large"
+          color="normal"
+          icon-name="arrow_back"
+          @click="$router.back()"
+        ></IconButton>
+      </template>
+      <template #title>詳細設定</template>
+    </PageHeader>
+    <div class="main">
+      <div class="main__contents">
+        <IcalDetailSettings v-model="value" :tags="tags" />
+      </div>
+      <div class="main__footer">
+        <Button
+          size="medium"
+          layout="fill"
+          color="primary"
+          :pauseActiveStyle="false"
+          @click="onSave"
+          >保存する</Button
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHead } from "@vueuse/head";
+import { onMounted } from "vue";
+import { useRouter } from "vue-router";
+import {
+  InternalServerError,
+  isResultError,
+  NetworkError,
+  UnauthenticatedError,
+} from "~/domain/error";
+import Button from "~/ui/components/Button.vue";
+import IcalDetailSettings from "~/ui/components/IcalDetailSettings.vue";
+import IconButton from "~/ui/components/IconButton.vue";
+import PageHeader from "~/ui/components/PageHeader.vue";
+import { useIcalDetailSettings } from "~/ui/hooks/useIcalDetailSettings";
+import { useToast } from "~/ui/store";
+
+useHead({
+  title: "Twin:te | カレンダー連携の詳細設定",
+});
+
+const router = useRouter();
+const { displayToast } = useToast();
+
+const { tags, value, load, save } = useIcalDetailSettings();
+
+onMounted(load);
+
+const onSave = async () => {
+  const result = await save();
+  if (!isResultError(result)) {
+    displayToast("表示設定を保存しました", { type: "primary" });
+    router.back();
+  } else if (result instanceof UnauthenticatedError) {
+    displayToast(
+      "ログインの確認に失敗しました。お手数ですが、再度ログインした上でお試しいただけますと幸いです。",
+      { type: "danger" }
+    );
+    router.push("/login");
+  } else if (result instanceof NetworkError) {
+    displayToast(
+      "ネットワークエラーが発生しました。お使いの端末がインターネットに接続されているか、今一度確認ください。",
+      { type: "danger" }
+    );
+  } else if (result instanceof InternalServerError) {
+    displayToast("サーバーエラーが発生しました。", { type: "danger" });
+  }
+};
+</script>
+
+<style scoped lang="scss">
+@import "~/ui/styles";
+.ical-settings {
+  @include max-width;
+}
+
+.main {
+  margin-top: $spacing-5;
+  display: flex;
+  flex-direction: column;
+  &__contents {
+    height: calc(#{$vh} - 14rem);
+    overflow-y: auto;
+    padding: 0 1.2rem;
+    margin: 0 -1.2rem;
+  }
+  &__footer {
+    flex-shrink: 0;
+    display: flex;
+    padding: $spacing-4 0;
+  }
+}
+</style>

--- a/front/src/ui/route.ts
+++ b/front/src/ui/route.ts
@@ -19,6 +19,7 @@ const Import = () => import("./pages/import.vue");
 const Login = () => import("./pages/login.vue");
 const News = () => import("./pages/news.vue");
 const Settings = () => import("./pages/settings.vue");
+const IcalSettings = () => import("./pages/settings/ical.vue");
 const ImportRoom = () => import("./pages/import-room/index.vue");
 const ImportRoomExcel = () => import("./pages/import-room/excel.vue");
 
@@ -35,6 +36,7 @@ const routes: RouteRecordRaw[] = [
     meta: { hasSidebar: false, hasWelcomeModal: false },
   },
   { path: "/settings", component: Settings },
+  { path: "/settings/ical", component: IcalSettings },
   { path: "/add", component: Add },
   { path: "/add/search", component: Search },
   { path: "/add/csv", component: CSV },

--- a/front/src/usecases/calendar.ts
+++ b/front/src/usecases/calendar.ts
@@ -5,17 +5,23 @@ import {
   PromiseClient,
   Transport,
 } from "@connectrpc/connect";
+import { IcalSubscriptionMode } from "~/domain/calendar";
 import {
   InternalServerError,
   NetworkError,
   UnauthenticatedError,
 } from "~/domain/error";
+import {
+  fromPBIcalSubscriptionMode,
+  toPBIcalSubscriptionMode,
+} from "~/infrastructure/api/converters/calendarv1";
+import { fromPBUUID, toPBUUID } from "~/infrastructure/api/converters/shared";
 import { CalendarService } from "~/infrastructure/api/gen/calendar/v1/service_connect";
 import { handleError } from "~/infrastructure/api/utils";
 
 export interface ICalendarUseCase {
   getIcalSubscriptionUrl(): Promise<
-    | { url: string }
+    | { url: string; mode: IcalSubscriptionMode; targetTagIds: string[] }
     | { url: null }
     | UnauthenticatedError
     | NetworkError
@@ -29,6 +35,11 @@ export interface ICalendarUseCase {
   disableIcalSubscription(): Promise<
     null | UnauthenticatedError | NetworkError | InternalServerError
   >;
+
+  updateIcalSubscription(
+    mode: IcalSubscriptionMode,
+    targetTagIds: string[]
+  ): Promise<null | UnauthenticatedError | NetworkError | InternalServerError>;
 }
 
 export class CalendarUseCase implements ICalendarUseCase {
@@ -39,7 +50,7 @@ export class CalendarUseCase implements ICalendarUseCase {
   }
 
   async getIcalSubscriptionUrl(): Promise<
-    | { url: string }
+    | { url: string; mode: IcalSubscriptionMode; targetTagIds: string[] }
     | { url: null }
     | UnauthenticatedError
     | NetworkError
@@ -49,7 +60,13 @@ export class CalendarUseCase implements ICalendarUseCase {
       .getIcalSubscriptionUrl({})
       .then((res) => {
         const url = res.url;
-        return url ? { url } : { url: null };
+        return url
+          ? {
+              url,
+              mode: fromPBIcalSubscriptionMode(res.mode),
+              targetTagIds: res.targetTagIds.map(fromPBUUID),
+            }
+          : { url: null };
       })
       .catch((error) => {
         return handleError(error, (connectError: ConnectError) => {
@@ -82,6 +99,26 @@ export class CalendarUseCase implements ICalendarUseCase {
   > {
     return this.#client
       .disableIcalSubscription({})
+      .then(() => null)
+      .catch((error) => {
+        return handleError(error, (connectError: ConnectError) => {
+          if (connectError.code === Code.Unauthenticated) {
+            return new UnauthenticatedError();
+          }
+          throw error;
+        });
+      });
+  }
+
+  async updateIcalSubscription(
+    mode: IcalSubscriptionMode,
+    targetTagIds: string[]
+  ): Promise<null | UnauthenticatedError | NetworkError | InternalServerError> {
+    return this.#client
+      .updateIcalSubscription({
+        mode: toPBIcalSubscriptionMode(mode),
+        targetTagIds: targetTagIds.map(toPBUUID),
+      })
       .then(() => null)
       .catch((error) => {
         return handleError(error, (connectError: ConnectError) => {


### PR DESCRIPTION
## 概要

closes #433（フロント側）/ depends on #445

PR #445（バックエンド）で追加された `IcalSubscription` の同期モード `mode`（`SYNC` / `EXCLUDE` / `TRANSPARENT`）と対象タグ `target_tag_ids` を設定するフロントエンドUIを実装します。

> **base は #445** にしています。#445 がマージされたら base を `master` に切り替えてください。

デザイン: 「カレンダー連携 設定UI案」（Claude Design）に準拠。バックエンドの3値 enum を **そのまま同期 / カレンダーに入れない / 予定なしにする** の日常語に翻訳し、**カレンダーの見た目（ミニプレビュー）で選ぶ** UIにまとめています。

## 変更内容

- **gen**: `bun run buf-gen` で再生成（`IcalSubscriptionMode` enum、`UpdateIcalSubscription` RPC、`GetIcalSubscriptionUrlResponse` の `mode` / `target_tag_ids`）
- **domain**: `IcalSubscriptionMode`（`"sync" | "exclude" | "transparent"`）と `IcalSubscription` を `front/src/domain/calendar.ts` に追加
- **converter**: `front/src/infrastructure/api/converters/calendarv1.ts` で mode の相互変換（既存の `fromPBModule` 等のパターンに踏襲）
- **usecase**: `getIcalSubscriptionUrl` が `mode` / `targetTagIds` も返すよう拡張し、`updateIcalSubscription(mode, targetTagIds)` を追加
- **ui**:
  - 設定画面のカレンダー連携セクションに **「詳細設定」ボタン** を追加（連携ON時のみ表示）
  - **PC＝モーダル**（既存 `Modal.vue`）・**SP＝サブページ** `/settings/ical` で出し分け（`large-screen` 相当の `useMediaQuery` で判定）
  - 対象タグを選び、挙動を **ミニカレンダープレビュー**（そのまま＝授業ブロック / 入れない＝破線枠 / 予定なし＝斜線ハッチ）で選ぶ共有コンポーネント `IcalDetailSettings.vue` を新設し、モーダル・サブページの双方で利用
  - 読み込み・保存ロジックは composable `useIcalDetailSettings` に集約
  - 不変条件の遵守: **対象タグが空のときは `SYNC` として保存**（`mode == SYNC ⇒ targetTagIds 空`）

## 実装メモ / 既存コードへの追従

- タグ一覧は既存の `timetableUseCase.listTags()` を再利用、タグチップは既存の `Tag.vue`、トースト/エラー処理・モーダル開閉(`useSwitch`)・ページ構成(`PageHeader` + 戻る) も既存パターンに合わせています。
- 配色・ニューモーフィズム影・グラデーションは `~/ui/styles` のトークン（`--primary-liner` / `$shadow-convex` / `$shadow-primary-concave` 等）を使用。

## 検証

- `bun run typecheck`（vue-tsc）/ `bun run lint`（eslint）/ `prettier --check` 通過
- `bun run test`（jest）**164 件すべて通過**
- `bun run buf-gen` を再実行し、生成物が手元の変更と一致することを確認（差分は calendar の2ファイルのみ）

## レビュー観点 / 相談

- PC/SP の出し分けに `@vueuse/core` の `useMediaQuery`（`(min-height: 860px), (orientation: landscape)`、`Modal` が PC レイアウトへ切り替わる `large-screen` mixin に合わせた条件）を導入しています。既存は `ua.ts` の `isMobile()`（ネイティブアプリ判定）ですが、今回は画面幅で判定したいため媒体クエリを採用しました。方針に意見があれば。

🤖 Generated with [Claude Code](https://claude.com/claude-code)